### PR TITLE
chore: deploy API frontend to API server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,10 @@ jobs:
 
       - name: Deploy to VM
         run: |
-          gcloud compute ssh ${{ secrets.DEV_INSTANCE_NAME }} \
+          gcloud compute ssh ${{ secrets.API_INSTANCE_NAME }} \
             --zone=${{ env.GCP_ZONE }} \
             --command="cd /app/api && git pull origin main && \
-                       cd /app/cl && sudo docker compose up --build -d fe"
+                       cd /app/cl/api && sudo docker compose up --build -d fe"
 
   notify:
     needs: deploy


### PR DESCRIPTION
## What
- Changed API frontend deployment target from dev server to API server
- Updated secret from `DEV_INSTANCE_NAME` to `API_INSTANCE_NAME`
- Updated path from `/app/cl` to `/app/cl/api` to match cl repo directory restructure

## Why
- API frontend (`api.ppa-dun.site`) should be served from the API server, not the dev server
- cl repo was restructured into `dev/` and `api/` directories

## Related Issue