### PR TITLE
fix: resolve /auth page refresh 404 by changing API prefix

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from backend.db.session import get_db
 from backend.db.models import User, APIKey
 
-router = APIRouter(prefix="/auth", tags=["auth"])
+router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 

--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -28,7 +28,7 @@ function Authentication() {
     setError("");
 
     try {
-      const res = await fetch(`${API_URL}/auth/google`, {
+      const res = await fetch(`${API_URL}/api/auth/google`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token: response.credential }),
@@ -49,7 +49,7 @@ function Authentication() {
 
   const fetchApiKeys = async (googleToken: string) => {
     try {
-      const res = await fetch(`${API_URL}/auth/api-keys?google_token=${googleToken}`);
+      const res = await fetch(`${API_URL}/api/auth/api-keys?google_token=${googleToken}`);
       if (res.ok) {
         const keys = await res.json();
         setApiKeys(keys);
@@ -61,7 +61,7 @@ function Authentication() {
 
   const createApiKey = async () => {
     try {
-      const res = await fetch(`${API_URL}/auth/api-key`, {
+      const res = await fetch(`${API_URL}/api/auth/api-key`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token }),


### PR DESCRIPTION
## What
- Changed backend auth router prefix from `/auth` to `/api/auth`
- Updated frontend API call URLs from `/auth/*` to `/api/auth/*`

## Why
Refreshing on `/auth` causes the browser to request `/auth/`, which nginx proxies to the FastAPI backend instead of serving the frontend. Since there is no `GET /auth/` route, it returns a 404 JSON response. Moving the API to `/api/auth` eliminates the conflict with frontend routes.

## Related Issue
Closes #27