### PR TITLE
fix: persist login state across page navigation

### DIFF
--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { GoogleLogin } from "@react-oauth/google";
 import type { CredentialResponse } from "@react-oauth/google";
 
@@ -16,11 +16,27 @@ interface User {
 }
 
 function Authentication() {
-  const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string>("");
+  const [user, setUser] = useState<User | null>(() => {
+    const saved = sessionStorage.getItem("user");
+    return saved ? JSON.parse(saved) : null;
+  });
+  const [token, setToken] = useState<string>(() => {
+    return sessionStorage.getItem("token") || "";
+  });
   const [apiKeys, setApiKeys] = useState<APIKey[]>([]);
   const [error, setError] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user && token) {
+      sessionStorage.setItem("user", JSON.stringify(user));
+      sessionStorage.setItem("token", token);
+      fetchApiKeys(token);
+    } else {
+      sessionStorage.removeItem("user");
+      sessionStorage.removeItem("token");
+    }
+  }, [user, token]);
 
   const handleLogin = async (response: CredentialResponse) => {
     if (!response.credential) return;


### PR DESCRIPTION
## What
Store `user` and `token` in `sessionStorage` and restore on component mount.

## Why
Login state was stored only in React `useState`, so navigating away from `/auth` and coming back would lose the login. Now the state persists until the browser tab is closed.

## Related Issue
Closes #29