### PR TITLE
feat: update dashboard — new endpoints, demo forms, algorithm docs (#35)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 import os
 from api.routers import player
-from api.services.player import compute_player_value
+from api.services.player import compute_player_value, compute_recommended_bid
+from api.models.player import PlayerValueRequest, PlayerBidRequest
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -22,7 +23,7 @@ app.add_middleware(
 
 @app.middleware("http")
 async def verify_api_key(request: Request, call_next):
-    # /health, /demo, and OPTIONS requests are exempt from API key check
+    # /health, /demo/*, and OPTIONS are always exempt
     if request.url.path == "/health" or request.url.path.startswith("/demo") or request.method == "OPTIONS":
         return await call_next(request)
 
@@ -58,7 +59,15 @@ def health_check():
     return {"status": "ok"}
 
 
-@app.get("/demo/{player_name}")
-def demo(player_name: str):
-    # Temporary demo endpoint - will be redesigned in Issue #35
-    return {"player_name": player_name, "note": "demo endpoint - Issue #35 pending"}
+# Demo endpoints — no API key required, intended for public dashboard demo only.
+# These call the same service functions as /player/value and /player/bid,
+# but are exposed without authentication so the key is never sent to the browser.
+
+@app.post("/demo/value")
+def demo_value(request: PlayerValueRequest):
+    return compute_player_value(request)
+
+
+@app.post("/demo/bid")
+def demo_bid(request: PlayerBidRequest):
+    return compute_recommended_bid(request)

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,109 +1,290 @@
 import { useState } from "react";
 
-interface Field {
-  key: string;
-  label: string;
-  placeholder: string;
-  enabled: boolean;
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
+type PlayerType = "batter" | "pitcher";
+type DemoMode = "value" | "bid";
+
+// ── Default form values ───────────────────────────────────────────────────────
+
+const DEFAULT_BATTER_STATS = { AB: 534, R: 113, HR: 37, RBI: 97, SB: 23, CS: 4, AVG: 0.281 };
+const DEFAULT_PITCHER_STATS = { IP: 200.0, W: 15, SV: 0, K: 220, ERA: 2.95, WHIP: 1.05 };
+const DEFAULT_LEAGUE = { league_size: 12, roster_size: 23, total_budget: 260 };
+const DEFAULT_DRAFT = { my_remaining_budget: 198, my_remaining_roster_spots: 17, my_positions_filled: "C, SP", drafted_players_count: 87 };
+
+// ── Score bar ─────────────────────────────────────────────────────────────────
+
+function ScoreBar({ value }: { value: number }) {
+  const pct = Math.max(0, Math.min(100, value));
+  const color =
+    pct >= 80 ? "bg-yellow-400" :
+    pct >= 60 ? "bg-green-400" :
+    pct >= 40 ? "bg-blue-400" :
+    pct >= 20 ? "bg-orange-400" : "bg-red-400";
+  const label =
+    pct >= 80 ? "Elite" :
+    pct >= 60 ? "Strong" :
+    pct >= 40 ? "Average" :
+    pct >= 20 ? "Below Average" : "Replacement Level";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-bold text-white/40 uppercase">player_value</span>
+        <span className={`text-xs font-bold ${color.replace("bg-", "text-")}`}>{label}</span>
+      </div>
+      <div className="relative h-3 w-full rounded-full bg-white/10 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="text-right text-2xl font-extrabold text-white">{value.toFixed(1)}</div>
+    </div>
+  );
 }
 
-const fields: Field[] = [
-  {
-    key: "player_name",
-    label: "Player Name",
-    placeholder: "e.g. Shohei Ohtani",
-    enabled: true,
-  },
-  // Add more stats here in the future
-  // { key: "avg", label: "AVG", placeholder: "e.g. 0.301", enabled: false },
-  // { key: "hr", label: "HR", placeholder: "e.g. 44", enabled: false },
-];
+// ── Breakdown table ───────────────────────────────────────────────────────────
+
+function BreakdownTable({ data }: { data: Record<string, number> }) {
+  return (
+    <div className="rounded-2xl border border-white/10 overflow-hidden">
+      <table className="w-full text-sm">
+        <tbody>
+          {Object.entries(data).map(([key, val], i, arr) => (
+            <tr key={key} className={i !== arr.length - 1 ? "border-b border-white/5" : ""}>
+              <td className="px-4 py-2 font-mono text-white/50 text-xs">{key}</td>
+              <td className="px-4 py-2 text-white/80 text-xs text-right font-bold">{val}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Input field ───────────────────────────────────────────────────────────────
+
+function InputField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-bold text-white/40 uppercase mb-1">{label}</p>
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2.5 text-sm text-white outline-none placeholder:text-white/20 focus:border-white/30 transition"
+      />
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 function Demo() {
-  const [values, setValues] = useState<Record<string, string>>({
-    player_name: "",
-  });
-  const [result, setResult] = useState<null | {
-    player_name: string;
-    recommended_bid: number;
-    player_value: number;
-  }>(null);
+  const [mode, setMode] = useState<DemoMode>("value");
+  const [playerType, setPlayerType] = useState<PlayerType>("batter");
+
+  // Shared fields
+  const [playerName, setPlayerName] = useState("Juan Soto");
+  const [position, setPosition] = useState("OF");
+
+  // Batter stats
+  const [batter, setBatter] = useState(
+    Object.fromEntries(Object.entries(DEFAULT_BATTER_STATS).map(([k, v]) => [k, String(v)]))
+  );
+  // Pitcher stats
+  const [pitcher, setPitcher] = useState(
+    Object.fromEntries(Object.entries(DEFAULT_PITCHER_STATS).map(([k, v]) => [k, String(v)]))
+  );
+  // League context
+  const [league, setLeague] = useState(
+    Object.fromEntries(Object.entries(DEFAULT_LEAGUE).map(([k, v]) => [k, String(v)]))
+  );
+  // Draft context (bid only)
+  const [draft, setDraft] = useState(
+    Object.fromEntries(Object.entries(DEFAULT_DRAFT).map(([k, v]) => [k, String(v)]))
+  );
+
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const handleChange = (key: string, value: string) => {
-    setValues((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const handleDemo = async () => {
-    if (!values.player_name) return;
-
+  const handleSubmit = async () => {
     setLoading(true);
     setError("");
     setResult(null);
 
     try {
-      const response = await fetch("http://localhost:8000/demo", {
+      const stats =
+        playerType === "batter"
+          ? {
+              AB: Number(batter.AB), R: Number(batter.R), HR: Number(batter.HR),
+              RBI: Number(batter.RBI), SB: Number(batter.SB), CS: Number(batter.CS),
+              AVG: Number(batter.AVG),
+            }
+          : {
+              IP: Number(pitcher.IP), W: Number(pitcher.W), SV: Number(pitcher.SV),
+              K: Number(pitcher.K), ERA: Number(pitcher.ERA), WHIP: Number(pitcher.WHIP),
+            };
+
+      const league_context = {
+        league_size: Number(league.league_size),
+        roster_size: Number(league.roster_size),
+        total_budget: Number(league.total_budget),
+      };
+
+      const body: Record<string, unknown> = {
+        player_name: playerName,
+        player_type: playerType,
+        position,
+        stats,
+        league_context,
+      };
+
+      if (mode === "bid") {
+        body.draft_context = {
+          my_remaining_budget: Number(draft.my_remaining_budget),
+          my_remaining_roster_spots: Number(draft.my_remaining_roster_spots),
+          my_positions_filled: draft.my_positions_filled.split(",").map((s) => s.trim()).filter(Boolean),
+          drafted_players_count: Number(draft.drafted_players_count),
+        };
+      }
+
+      const endpoint = mode === "value" ? "/demo/value" : "/demo/bid";
+      const res = await fetch(`${API_URL}${endpoint}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ player_name: values.player_name }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
       });
 
-      if (!response.ok) {
-        setError("Something went wrong. Please try again.");
+      if (!res.ok) {
+        const err = await res.json();
+        setError(err.detail || "Something went wrong.");
         return;
       }
 
-      const data = await response.json();
-      setResult(data);
-    } catch (e) {
+      setResult(await res.json());
+    } catch {
       setError("Failed to connect to the API.");
     } finally {
       setLoading(false);
     }
   };
 
+  const batterFields = ["AB", "R", "HR", "RBI", "SB", "CS", "AVG"] as const;
+  const pitcherFields = ["IP", "W", "SV", "K", "ERA", "WHIP"] as const;
+
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center px-6 pt-24 pb-16">
+    <div className="relative min-h-screen flex flex-col items-center px-6 pt-24 pb-16">
       <div className="absolute inset-0 bg-gradient-to-b from-white/5 to-black pointer-events-none" />
 
-      <div className="relative z-10 max-w-2xl w-full">
+      <div className="relative z-10 max-w-2xl w-full space-y-8">
 
-        <h1 className="text-4xl font-extrabold tracking-tight text-white mb-2">
-          Try it out
-        </h1>
-        <p className="text-white/50 text-sm mb-10">
-          Enter a player name and see the API response in real time.
-        </p>
+        {/* Header */}
+        <div>
+          <h1 className="text-4xl font-extrabold tracking-tight text-white mb-2">Try it out</h1>
+          <p className="text-white/50 text-sm">
+            Enter player stats and see the API response in real time.
+          </p>
+        </div>
 
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-4">
-          {/* Input fields */}
-          {fields
-            .filter((f) => f.enabled)
-            .map((f) => (
-              <div key={f.key}>
-                <p className="text-xs font-bold text-white/40 uppercase mb-2">
-                  {f.label}
-                </p>
-                <input
-                  type="text"
-                  placeholder={f.placeholder}
-                  value={values[f.key] || ""}
-                  onChange={(e) => handleChange(f.key, e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleDemo();
-                  }}
-                  className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30"
-                />
+        {/* Mode toggle */}
+        <div className="flex gap-2">
+          {(["value", "bid"] as DemoMode[]).map((m) => (
+            <button
+              key={m}
+              onClick={() => { setMode(m); setResult(null); setError(""); }}
+              className={`rounded-lg px-4 py-1.5 text-xs font-bold transition ${
+                mode === m ? "bg-white text-black" : "bg-white/10 text-white/50 hover:bg-white/20"
+              }`}
+            >
+              {m === "value" ? "POST /demo/value" : "POST /demo/bid"}
+            </button>
+          ))}
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-5">
+
+          {/* Player info */}
+          <div className="grid grid-cols-2 gap-4">
+            <InputField label="Player Name" value={playerName} onChange={setPlayerName} placeholder="e.g. Juan Soto" />
+            <InputField label="Position" value={position} onChange={setPosition} placeholder="e.g. OF" />
+          </div>
+
+          {/* Player type toggle */}
+          <div>
+            <p className="text-xs font-bold text-white/40 uppercase mb-2">Player Type</p>
+            <div className="flex gap-2">
+              {(["batter", "pitcher"] as PlayerType[]).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setPlayerType(t)}
+                  className={`rounded-lg px-4 py-1.5 text-xs font-bold transition ${
+                    playerType === t ? "bg-white text-black" : "bg-white/10 text-white/50 hover:bg-white/20"
+                  }`}
+                >
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div>
+            <p className="text-xs font-bold text-white/40 uppercase mb-3">Stats</p>
+            <div className="grid grid-cols-3 gap-3">
+              {playerType === "batter"
+                ? batterFields.map((f) => (
+                    <InputField key={f} label={f} value={batter[f]} onChange={(v) => setBatter((p) => ({ ...p, [f]: v }))} />
+                  ))
+                : pitcherFields.map((f) => (
+                    <InputField key={f} label={f} value={pitcher[f]} onChange={(v) => setPitcher((p) => ({ ...p, [f]: v }))} />
+                  ))}
+            </div>
+          </div>
+
+          {/* League context */}
+          <div>
+            <p className="text-xs font-bold text-white/40 uppercase mb-3">League Context</p>
+            <div className="grid grid-cols-3 gap-3">
+              {(["league_size", "roster_size", "total_budget"] as const).map((f) => (
+                <InputField key={f} label={f} value={league[f]} onChange={(v) => setLeague((p) => ({ ...p, [f]: v }))} />
+              ))}
+            </div>
+          </div>
+
+          {/* Draft context (bid only) */}
+          {mode === "bid" && (
+            <div>
+              <p className="text-xs font-bold text-white/40 uppercase mb-3">Draft Context</p>
+              <div className="grid grid-cols-2 gap-3">
+                <InputField label="my_remaining_budget" value={draft.my_remaining_budget} onChange={(v) => setDraft((p) => ({ ...p, my_remaining_budget: v }))} />
+                <InputField label="my_remaining_roster_spots" value={draft.my_remaining_roster_spots} onChange={(v) => setDraft((p) => ({ ...p, my_remaining_roster_spots: v }))} />
+                <InputField label="my_positions_filled (comma separated)" value={draft.my_positions_filled} onChange={(v) => setDraft((p) => ({ ...p, my_positions_filled: v }))} placeholder="e.g. C, SP, OF" />
+                <InputField label="drafted_players_count" value={draft.drafted_players_count} onChange={(v) => setDraft((p) => ({ ...p, drafted_players_count: v }))} />
               </div>
-            ))}
+            </div>
+          )}
 
-          {/* Submit button */}
+          {/* Submit */}
           <button
-            onClick={handleDemo}
+            onClick={handleSubmit}
             disabled={loading}
-            className="w-full rounded-xl bg-white py-3 text-sm font-extrabold text-black
-                       transition hover:bg-white/90 active:scale-95 disabled:opacity-40"
+            className="w-full rounded-xl bg-white py-3 text-sm font-extrabold text-black transition hover:bg-white/90 active:scale-95 disabled:opacity-40"
           >
             {loading ? "Loading..." : "Submit"}
           </button>
@@ -116,16 +297,48 @@ function Demo() {
           )}
 
           {/* Result */}
-          {result && (
-            <div>
-              <p className="text-xs font-bold text-white/40 uppercase mb-2">
-                Response
-              </p>
-              <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 whitespace-pre-wrap break-all">
-                {JSON.stringify(result, null, 2)}
-              </pre>
-            </div>
-          )}
+          {result && (() => {
+            const playerValue = typeof result.player_value === "number" ? result.player_value : null;
+            const recommendedBid = typeof result.recommended_bid === "number" ? result.recommended_bid : null;
+            const valueBreakdown = result.value_breakdown !== null && typeof result.value_breakdown === "object" ? result.value_breakdown as Record<string, number> : null;
+            const bidBreakdown = result.bid_breakdown !== null && typeof result.bid_breakdown === "object" ? result.bid_breakdown as Record<string, number> : null;
+
+            return (
+              <div className="space-y-4">
+                <p className="text-xs font-bold text-white/40 uppercase">Response</p>
+
+                {playerValue !== null && <ScoreBar value={playerValue} />}
+
+                {recommendedBid !== null && (
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4 flex items-center justify-between">
+                    <span className="text-xs font-bold text-white/40 uppercase">recommended_bid</span>
+                    <span className="text-2xl font-extrabold text-white">${recommendedBid}</span>
+                  </div>
+                )}
+
+                {valueBreakdown !== null && (
+                  <div>
+                    <p className="text-xs font-bold text-white/40 uppercase mb-2">value_breakdown</p>
+                    <BreakdownTable data={valueBreakdown} />
+                  </div>
+                )}
+
+                {bidBreakdown !== null && (
+                  <div>
+                    <p className="text-xs font-bold text-white/40 uppercase mb-2">bid_breakdown</p>
+                    <BreakdownTable data={bidBreakdown} />
+                  </div>
+                )}
+
+                <div>
+                  <p className="text-xs font-bold text-white/40 uppercase mb-2">Raw JSON</p>
+                  <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-xs text-white/60 whitespace-pre-wrap break-all overflow-auto">
+                    {JSON.stringify(result, null, 2)}
+                  </pre>
+                </div>
+              </div>
+            );
+          })()}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Endpoints.tsx
+++ b/frontend/src/pages/Endpoints.tsx
@@ -1,62 +1,285 @@
+import { useState } from "react";
+
+type Tab = "batter" | "pitcher";
+
+interface SchemaRow {
+  field: string;
+  type: string;
+  description: string;
+}
+
+interface EndpointCardProps {
+  method: string;
+  path: string;
+  description: string;
+  batterRequest: object;
+  pitcherRequest: object;
+  batterResponse: object;
+  pitcherResponse: object;
+  schema: SchemaRow[];
+}
+
+function EndpointCard({
+  method,
+  path,
+  description,
+  batterRequest,
+  pitcherRequest,
+  batterResponse,
+  pitcherResponse,
+  schema,
+}: EndpointCardProps) {
+  const [tab, setTab] = useState<Tab>("batter");
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-6">
+      {/* Title */}
+      <div className="flex items-center gap-3">
+        <span className="rounded-lg bg-white/10 px-3 py-1 text-xs font-bold text-white">
+          {method}
+        </span>
+        <span className="text-white font-bold">{path}</span>
+      </div>
+      <p className="text-sm text-white/50">{description}</p>
+
+      {/* Batter / Pitcher toggle */}
+      <div className="flex gap-2">
+        {(["batter", "pitcher"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-lg px-4 py-1.5 text-xs font-bold transition ${
+              tab === t
+                ? "bg-white text-black"
+                : "bg-white/10 text-white/50 hover:bg-white/20"
+            }`}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Request */}
+      <div>
+        <p className="text-xs font-bold text-white/40 uppercase mb-2">Request</p>
+        <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 whitespace-pre-wrap break-all overflow-auto">
+          {JSON.stringify(tab === "batter" ? batterRequest : pitcherRequest, null, 2)}
+        </pre>
+      </div>
+
+      {/* Response */}
+      <div>
+        <p className="text-xs font-bold text-white/40 uppercase mb-2">Response</p>
+        <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 whitespace-pre-wrap break-all overflow-auto">
+          {JSON.stringify(tab === "batter" ? batterResponse : pitcherResponse, null, 2)}
+        </pre>
+      </div>
+
+      {/* Schema table */}
+      <div>
+        <p className="text-xs font-bold text-white/40 uppercase mb-3">Request Fields</p>
+        <div className="rounded-2xl border border-white/10 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/10 bg-white/5">
+                <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Field</th>
+                <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Type</th>
+                <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {schema.map((row, i) => (
+                <tr key={row.field} className={i !== schema.length - 1 ? "border-b border-white/5" : ""}>
+                  <td className="px-4 py-2 font-mono text-white/80 text-xs">{row.field}</td>
+                  <td className="px-4 py-2 text-white/40 text-xs">{row.type}</td>
+                  <td className="px-4 py-2 text-white/50 text-xs">{row.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Required header */}
+      <div>
+        <p className="text-xs font-bold text-white/40 uppercase mb-2">Required Header</p>
+        <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80">
+          X-API-Key: your_api_key_here
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+// ── Data ─────────────────────────────────────────────────────────────────────
+
+const VALUE_BATTER_REQUEST = {
+  player_name: "Juan Soto",
+  player_type: "batter",
+  position: "OF",
+  stats: { AB: 534, R: 113, HR: 37, RBI: 97, SB: 23, CS: 4, AVG: 0.281 },
+  league_context: { league_size: 12, roster_size: 23, total_budget: 260 },
+};
+
+const VALUE_PITCHER_REQUEST = {
+  player_name: "Zack Wheeler",
+  player_type: "pitcher",
+  position: "SP",
+  stats: { IP: 200.0, W: 15, SV: 0, K: 220, ERA: 2.95, WHIP: 1.05 },
+  league_context: { league_size: 12, roster_size: 23, total_budget: 260 },
+};
+
+const VALUE_BATTER_RESPONSE = {
+  player_name: "Juan Soto",
+  player_type: "batter",
+  player_value: 87.4,
+  value_breakdown: { stat_score: 82.6, position_bonus: 0.0, risk_penalty: 0.0 },
+};
+
+const VALUE_PITCHER_RESPONSE = {
+  player_name: "Zack Wheeler",
+  player_type: "pitcher",
+  player_value: 79.2,
+  value_breakdown: { stat_score: 74.1, position_bonus: 3.3, risk_penalty: 0.0 },
+};
+
+const BID_BATTER_REQUEST = {
+  player_name: "Juan Soto",
+  player_type: "batter",
+  position: "OF",
+  stats: { AB: 534, R: 113, HR: 37, RBI: 97, SB: 23, CS: 4, AVG: 0.281 },
+  league_context: { league_size: 12, roster_size: 23, total_budget: 260 },
+  draft_context: {
+    my_remaining_budget: 198,
+    my_remaining_roster_spots: 17,
+    my_positions_filled: ["C", "SP"],
+    drafted_players_count: 87,
+  },
+};
+
+const BID_PITCHER_REQUEST = {
+  player_name: "Zack Wheeler",
+  player_type: "pitcher",
+  position: "SP",
+  stats: { IP: 200.0, W: 15, SV: 0, K: 220, ERA: 2.95, WHIP: 1.05 },
+  league_context: { league_size: 12, roster_size: 23, total_budget: 260 },
+  draft_context: {
+    my_remaining_budget: 198,
+    my_remaining_roster_spots: 17,
+    my_positions_filled: ["OF", "1B"],
+    drafted_players_count: 87,
+  },
+};
+
+const BID_BATTER_RESPONSE = {
+  player_name: "Juan Soto",
+  player_type: "batter",
+  player_value: 87.4,
+  recommended_bid: 42,
+  bid_breakdown: {
+    base_price: 40.4,
+    scarcity_adjustment: 0.0,
+    draft_adjustment: 1.6,
+    max_spendable: 181,
+  },
+};
+
+const BID_PITCHER_RESPONSE = {
+  player_name: "Zack Wheeler",
+  player_type: "pitcher",
+  player_value: 79.2,
+  recommended_bid: 29,
+  bid_breakdown: {
+    base_price: 27.1,
+    scarcity_adjustment: 1.4,
+    draft_adjustment: 0.5,
+    max_spendable: 181,
+  },
+};
+
+const VALUE_SCHEMA: SchemaRow[] = [
+  { field: "player_name", type: "string", description: "Player full name" },
+  { field: "player_type", type: '"batter" | "pitcher"', description: "Player type" },
+  { field: "position", type: "string", description: 'Position (e.g. "OF", "SP", "C")' },
+  { field: "stats.AB", type: "int", description: "At bats (batter only)" },
+  { field: "stats.R", type: "int", description: "Runs (batter only)" },
+  { field: "stats.HR", type: "int", description: "Home runs (batter only)" },
+  { field: "stats.RBI", type: "int", description: "Runs batted in (batter only)" },
+  { field: "stats.SB", type: "int", description: "Stolen bases (batter only)" },
+  { field: "stats.CS", type: "int", description: "Caught stealing (batter only)" },
+  { field: "stats.AVG", type: "float", description: "Batting average (batter only)" },
+  { field: "stats.IP", type: "float", description: "Innings pitched (pitcher only)" },
+  { field: "stats.W", type: "int", description: "Wins (pitcher only)" },
+  { field: "stats.SV", type: "int", description: "Saves (pitcher only)" },
+  { field: "stats.K", type: "int", description: "Strikeouts (pitcher only)" },
+  { field: "stats.ERA", type: "float", description: "Earned run average (pitcher only)" },
+  { field: "stats.WHIP", type: "float", description: "Walks + hits per inning (pitcher only)" },
+  { field: "league_context.league_size", type: "int", description: "Number of teams in the league" },
+  { field: "league_context.roster_size", type: "int", description: "Roster spots per team" },
+  { field: "league_context.total_budget", type: "int", description: "Auction budget per team ($)" },
+];
+
+const BID_SCHEMA: SchemaRow[] = [
+  ...VALUE_SCHEMA,
+  { field: "draft_context.my_remaining_budget", type: "int", description: "Your remaining auction budget ($)" },
+  { field: "draft_context.my_remaining_roster_spots", type: "int", description: "Roster spots you still need to fill" },
+  { field: "draft_context.my_positions_filled", type: "string[]", description: "Positions you have already filled" },
+  { field: "draft_context.drafted_players_count", type: "int", description: "Total players drafted across all teams so far" },
+];
+
+const TIERS = [
+  { label: "Elite", range: "80 – 100", color: "text-yellow-400", bg: "bg-yellow-400/10 border-yellow-400/20" },
+  { label: "Strong", range: "60 – 79", color: "text-green-400", bg: "bg-green-400/10 border-green-400/20" },
+  { label: "Average", range: "40 – 59", color: "text-blue-400", bg: "bg-blue-400/10 border-blue-400/20" },
+  { label: "Below Average", range: "20 – 39", color: "text-orange-400", bg: "bg-orange-400/10 border-orange-400/20" },
+  { label: "Replacement Level", range: "0 – 19", color: "text-red-400", bg: "bg-red-400/10 border-red-400/20" },
+];
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
 function Endpoints() {
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center px-6 pt-24 pb-16">
+    <div className="relative min-h-screen flex flex-col items-center px-6 pt-24 pb-16">
       <div className="absolute inset-0 bg-gradient-to-b from-white/5 to-black pointer-events-none" />
 
-      <div className="relative z-10 max-w-2xl w-full">
+      <div className="relative z-10 max-w-2xl w-full space-y-16">
 
-        <h1 className="text-4xl font-extrabold tracking-tight text-white mb-2">
-          Endpoints
-        </h1>
-        <p className="text-white/50 text-sm mb-10">
-          All endpoints except /health and /demo require an API Key.
-        </p>
-
-        {/* Endpoint Card */}
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-6">
-          {/* Title */}
-          <div className="flex items-center gap-3">
-            <span className="rounded-lg bg-white/10 px-3 py-1 text-xs font-bold text-white">
-              POST
-            </span>
-            <span className="text-white font-bold">/player</span>
-          </div>
-          <p className="text-sm text-white/50">
-            Returns a recommended bid and player value for a given player name.
+        {/* Header */}
+        <div>
+          <h1 className="text-4xl font-extrabold tracking-tight text-white mb-2">
+            Endpoints
+          </h1>
+          <p className="text-white/50 text-sm">
+            All endpoints except <code className="text-white/70">/health</code> and{" "}
+            <code className="text-white/70">/demo</code> require an API Key.
+            Scoring format: <span className="text-white/70">Rotisserie 5x5 (Roto 5x5)</span>.
           </p>
-
-          {/* Request */}
-          <div>
-            <p className="text-xs font-bold text-white/40 uppercase mb-2">Request</p>
-            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80">
-              {JSON.stringify({ player_name: "Shohei Ohtani" }, null, 2)}
-            </pre>
-          </div>
-
-          {/* Response */}
-          <div>
-            <p className="text-xs font-bold text-white/40 uppercase mb-2">Response</p>
-            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80">
-              {JSON.stringify(
-                {
-                  player_name: "Shohei Ohtani",
-                  recommended_bid: 42,
-                  player_value: 87,
-                },
-                null,
-                2
-              )}
-            </pre>
-          </div>
-
-          {/* Header */}
-          <div>
-            <p className="text-xs font-bold text-white/40 uppercase mb-2">Required Header</p>
-            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80">
-              X-API-Key: your_api_key_here
-            </pre>
-          </div>
         </div>
+
+        {/* /player/value */}
+        <EndpointCard
+          method="POST"
+          path="/player/value"
+          description="Returns player_value (0.0 ~ 100.0) based on Roto 5x5 z-score valuation. Supports both batters and pitchers."
+          batterRequest={VALUE_BATTER_REQUEST}
+          pitcherRequest={VALUE_PITCHER_REQUEST}
+          batterResponse={VALUE_BATTER_RESPONSE}
+          pitcherResponse={VALUE_PITCHER_RESPONSE}
+          schema={VALUE_SCHEMA}
+        />
+
+        {/* /player/bid */}
+        <EndpointCard
+          method="POST"
+          path="/player/bid"
+          description="Returns player_value and recommended_bid (integer $) adjusted for positional scarcity and real-time draft context."
+          batterRequest={BID_BATTER_REQUEST}
+          pitcherRequest={BID_PITCHER_REQUEST}
+          batterResponse={BID_BATTER_RESPONSE}
+          pitcherResponse={BID_PITCHER_RESPONSE}
+          schema={BID_SCHEMA}
+        />
+
       </div>
     </div>
   );

--- a/frontend/src/pages/Hero.tsx
+++ b/frontend/src/pages/Hero.tsx
@@ -1,11 +1,11 @@
 function Hero() {
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center px-6">
+    <div className="relative flex flex-col items-center px-6 pb-24">
       {/* Background Gradient */}
       <div className="absolute inset-0 bg-gradient-to-b from-white/5 to-black pointer-events-none" />
 
-      {/* Content */}
-      <div className="relative z-10 max-w-2xl text-center">
+      {/* Hero section */}
+      <div className="relative z-10 max-w-2xl text-center pt-32 pb-24">
         <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-xs text-white/50 mb-6">
           PPA-DUN Evaluator · Fantasy Baseball
         </div>
@@ -16,13 +16,245 @@ function Hero() {
 
         <p className="mt-6 text-lg text-white/60 leading-relaxed">
           A player valuation API for fantasy baseball draft kits.
-          Send a player name, get back a recommended bid and player value —
-          instantly.
+          Send player stats, get back a recommended bid and player value — instantly.
         </p>
 
         <div className="mt-4 text-sm text-white/30">
           Designed to be licensed and integrated into any fantasy baseball platform.
         </div>
+      </div>
+
+      {/* Algorithm section */}
+      <div className="relative z-10 max-w-2xl w-full space-y-6">
+
+        <div>
+          <h2 className="text-2xl font-extrabold tracking-tight text-white mb-2">
+            How it works
+          </h2>
+          <p className="text-white/50 text-sm">
+            All valuations use <span className="text-white/70">Rotisserie 5x5 (Roto 5x5)</span> scoring —
+            the most widely adopted fantasy baseball format. Every number the API returns
+            is traceable back to a concrete formula.
+          </p>
+        </div>
+
+        {/* ── player_value ── */}
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-6">
+
+          <div>
+            <p className="text-xs font-bold text-white/40 uppercase mb-1">Output field</p>
+            <p className="text-white text-lg font-extrabold">player_value <span className="text-white/40 font-normal text-sm">float · 0.0 ~ 100.0</span></p>
+          </div>
+
+          <p className="text-sm text-white/60 leading-relaxed">
+            Measures how valuable a player is relative to a league-average player pool,
+            normalized to a 0–100 scale. A value of <span className="text-white/80">50</span> means perfectly average.
+            A value of <span className="text-white/80">80+</span> means elite — top tier across multiple categories.
+          </p>
+
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 1 — Z-Score per category</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              For each of the 5 Roto categories, we compute how far the player deviates
+              from the league-average baseline in units of standard deviation.
+              A z-score of <span className="text-white/80">+1.0</span> means one standard deviation above average —
+              roughly top 16% of the player pool.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`z(stat) = (player_stat - league_mean) / league_std
+
+Batter categories:   R, HR, RBI, SB, AVG
+Pitcher categories:  W, SV, K, ERA, WHIP
+
+// ERA and WHIP are inverted — lower is better
+z(ERA)  = -(player_ERA  - mean_ERA)  / std_ERA
+z(WHIP) = -(player_WHIP - mean_WHIP) / std_WHIP`}
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 2 — Sum z-scores</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              The five z-scores are summed into a single number representing
+              the player's total contribution across all Roto categories.
+              A player who excels in multiple categories scores higher than
+              a specialist who dominates only one.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`z_total = z(R) + z(HR) + z(RBI) + z(SB) + z(AVG)
+        // or for pitchers:
+z_total = z(W) + z(SV) + z(K) + z(ERA) + z(WHIP)`}
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 3 — Position bonus & risk penalty</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              Positional scarcity is factored in as a bonus: catchers and shortstops
+              are harder to replace, so they receive a higher bonus.
+              Risk penalties are subtracted for players with low playing time
+              or poor efficiency (e.g. caught stealing rate, high ERA).
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`raw_score = z_total + position_bonus - risk_penalty
+
+Position bonus (z units):
+  C   +1.5    SS  +0.8    2B  +0.5
+  SP  +0.4    3B  +0.3    RP  +0.6
+  1B   0.0    OF   0.0    DH   0.0
+
+Risk penalty (z units):
+  Batter  AB < 300              → -0.5
+  Batter  CS / (SB+CS) > 35%   → -0.2
+  Pitcher IP < 100              → -0.5
+  Pitcher ERA > 4.50            → -0.3`}
+            </pre>
+          </div>
+
+          {/* Step 4 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 4 — Normalize to 0–100</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              The raw score is scaled against a theoretical maximum (elite all-around player)
+              and clipped to the 0–100 range. This makes the output intuitive:
+              any two players can be compared on the same scale regardless of position or type.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`player_value = clip((raw_score / RAW_MAX) * 100, 0, 100)`}
+            </pre>
+          </div>
+
+          {/* Tier table */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Value tiers</p>
+            <div className="rounded-2xl border border-white/10 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 bg-white/5">
+                    <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Tier</th>
+                    <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Range</th>
+                    <th className="text-left px-4 py-2 text-xs font-bold text-white/40 uppercase">Meaning</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[
+                    { label: "Elite", range: "80 – 100", color: "text-yellow-400", meaning: "Top-tier player, draft early" },
+                    { label: "Strong", range: "60 – 79", color: "text-green-400", meaning: "Reliable starter, solid value" },
+                    { label: "Average", range: "40 – 59", color: "text-blue-400", meaning: "League-average contributor" },
+                    { label: "Below Average", range: "20 – 39", color: "text-orange-400", meaning: "Situational or streaky value" },
+                    { label: "Replacement", range: "0 – 19", color: "text-red-400", meaning: "Waiver wire / bench depth only" },
+                  ].map((tier, i, arr) => (
+                    <tr key={tier.label} className={i !== arr.length - 1 ? "border-b border-white/5" : ""}>
+                      <td className={`px-4 py-2 font-bold text-xs ${tier.color}`}>{tier.label}</td>
+                      <td className="px-4 py-2 text-white/50 text-xs">{tier.range}</td>
+                      <td className="px-4 py-2 text-white/40 text-xs">{tier.meaning}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+        </div>
+
+        {/* ── recommended_bid ── */}
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-6">
+
+          <div>
+            <p className="text-xs font-bold text-white/40 uppercase mb-1">Output field</p>
+            <p className="text-white text-lg font-extrabold">recommended_bid <span className="text-white/40 font-normal text-sm">integer · dollar amount ($)</span></p>
+          </div>
+
+          <p className="text-sm text-white/60 leading-relaxed">
+            Translates <span className="text-white/80">player_value</span> into a concrete dollar bid
+            for auction drafts. The bid accounts for your remaining budget, how far
+            into the draft you are, and the positional scarcity of the player.
+            It is always at least <span className="text-white/80">$1</span> and never exceeds what you can safely spend.
+          </p>
+
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 1 — Base price from player_value</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              The total auction budget is split 67% to hitters and 33% to pitchers
+              (standard Roto 5x5 convention). The player's share of that pool
+              is proportional to their player_value.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`HIT_PITCH_RATIO = 0.67  // for batters
+                  0.33  // for pitchers
+
+base_price = (player_value / 100) * total_budget * HIT_PITCH_RATIO`}
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 2 — Positional scarcity multiplier</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              Scarce positions command a premium in auction drafts because
+              fewer quality options exist. A catcher worth 80 should cost
+              more than an outfielder worth 80 — because replacing that
+              catcher with the next best option is much harder.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`adjusted_price = base_price * scarcity_multiplier
+
+Scarcity multipliers:
+  C    ×1.15    SS   ×1.08    2B   ×1.05
+  SP   ×1.05    RP   ×1.05    3B   ×1.02
+  1B   ×1.00    OF   ×1.00    DH   ×1.00`}
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 3 — Draft progress adjustment</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              As the draft progresses, your spending behavior should shift.
+              Early on, you have budget to be aggressive. Late in the draft,
+              you need to preserve enough for remaining roster spots.
+              This step adjusts the bid based on how much of your budget
+              is left and how far into the draft the league is.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`draft_progress = drafted_players_count / (league_size * roster_size)
+budget_ratio   = spendable / my_remaining_budget
+
+// If budget_ratio > 0.5 → you have room to spend more
+// If budget_ratio < 0.5 → tighten up
+draft_multiplier = 1.0 + (budget_ratio - 0.5) * 0.2 * draft_progress
+
+recommended_bid = clip(
+  round(adjusted_price * draft_multiplier),
+  min = 1,
+  max = spendable           // never exceed what you can safely spend
+)`}
+            </pre>
+          </div>
+
+          {/* Step 4 */}
+          <div className="space-y-3">
+            <p className="text-xs font-bold text-white/40 uppercase">Step 4 — Budget ceiling (max_spendable)</p>
+            <p className="text-sm text-white/60 leading-relaxed">
+              You must always keep at least $1 per remaining roster spot
+              so you can fill out your team. The maximum you can safely
+              bid on any single player is your remaining budget minus
+              the number of empty roster spots still to fill.
+            </p>
+            <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 overflow-auto">
+{`min_reserve  = my_remaining_roster_spots - 1
+spendable    = my_remaining_budget - min_reserve
+
+// recommended_bid is always capped at spendable`}
+            </pre>
+          </div>
+
+        </div>
+
       </div>
     </div>
   );


### PR DESCRIPTION
## What

### api/main.py
- Added `POST /demo/value` and `POST /demo/bid` endpoints (no auth required)
- Removed `/demo/{player_name}` placeholder endpoint
- `/demo/*` routes call service functions directly — API key is never exposed to the browser

### frontend/src/pages/Endpoints.tsx
- Replaced old `POST /player` single endpoint card with two new cards:
  `POST /player/value` and `POST /player/bid`
- Added Batter / Pitcher tab toggle per endpoint card
- Added request schema tables and example request/response blocks for both endpoints
- Removed algorithm section (moved to Hero page)

### frontend/src/pages/Demo.tsx
- Rebuilt demo form to support both `/demo/value` and `/demo/bid`
- Added player_type toggle (Batter / Pitcher) that switches visible stat fields
- Added Draft Context fields that appear only when `/demo/bid` tab is selected
- Output panel: score bar (0~100 visual), recommended_bid highlight, breakdown tables
- Removed API key from frontend — demo calls go through `/demo/*` endpoints instead

### frontend/src/pages/Hero.tsx
- Added "How it works" algorithm section below the hero copy
- `player_value`: 4-step explanation with formulas (z-score → sum → bonus/penalty → normalize)
- `recommended_bid`: 4-step explanation with formulas (base price → scarcity → draft adjustment → budget ceiling)
- Added value tier table with Meaning column (Elite / Strong / Average / Below Average / Replacement)

## Why
- Dashboard now serves as the public-facing interface for developers
  who want to understand and test the PPA-DUN API
- Algorithm section gives API consumers full transparency into
  how `player_value` and `recommended_bid` are computed
- Demo key is no longer exposed to the browser — security improved
  by routing demo traffic through dedicated `/demo/*` endpoints

## Related Issue
#35 