### PR TITLE
fix: remove unused imports, update CORS origins, fix curl example

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -15,7 +15,11 @@ API_KEY = os.getenv("API_KEY")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[
+      "http://localhost:5173",       # local development                                                                                        
+      "http://dev.ppa-dun.site",     # dev                                                                                              
+      "https://ppa-dun.site",        # prod                                                                                   
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/api/models/player.py
+++ b/api/models/player.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from typing import Optional
 
 
 # ── Stat Models ─────────────────────────────────────────────────────────────

--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -192,10 +192,16 @@ function Authentication() {
                 X-API-Key: your_api_key_here
               </pre>
               <pre className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/80 whitespace-pre-wrap break-all">
-                {`curl -X POST https://api.ppa-dun.site/api/player \\
+{`curl -X POST https://api.ppa-dun.site/player/value \\
   -H "Content-Type: application/json" \\
   -H "X-API-Key: your_api_key_here" \\
-  -d '{"player_name": "Shohei Ohtani"}'`}
+  -d '{
+    "player_name": "Shohei Ohtani",
+    "player_type": "batter",
+    "position": "DH",
+    "stats": {"AB": 536, "R": 102, "HR": 44, "RBI": 96, "SB": 20, "CS": 6, "AVG": 0.310},
+    "league_context": {"league_size": 12, "roster_size": 23, "total_budget": 260}
+  }'`}
               </pre>
             </div>
           </div>

--- a/frontend/src/pages/Endpoints.tsx
+++ b/frontend/src/pages/Endpoints.tsx
@@ -227,14 +227,6 @@ const BID_SCHEMA: SchemaRow[] = [
   { field: "draft_context.drafted_players_count", type: "int", description: "Total players drafted across all teams so far" },
 ];
 
-const TIERS = [
-  { label: "Elite", range: "80 – 100", color: "text-yellow-400", bg: "bg-yellow-400/10 border-yellow-400/20" },
-  { label: "Strong", range: "60 – 79", color: "text-green-400", bg: "bg-green-400/10 border-green-400/20" },
-  { label: "Average", range: "40 – 59", color: "text-blue-400", bg: "bg-blue-400/10 border-blue-400/20" },
-  { label: "Below Average", range: "20 – 39", color: "text-orange-400", bg: "bg-orange-400/10 border-orange-400/20" },
-  { label: "Replacement Level", range: "0 – 19", color: "text-red-400", bg: "bg-red-400/10 border-red-400/20" },
-];
-
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 function Endpoints() {


### PR DESCRIPTION
## What
- `api/main.py` — Added dev and prod domains to CORS `allow_origins`
- `api/models/player.py` — Removed unused `Optional` import from `typing`
- `frontend/src/pages/Endpoints.tsx` — Removed unused `TIERS` constant (was causing TS6133 build error)
- `frontend/src/pages/Authentication.tsx` — Updated curl example to reflect new `/player/value` endpoint with full request body

## Why
- CORS was only allowing `localhost:5173`, blocking requests from deployed environments
- Unused `TIERS` and `Optional` were causing TypeScript/Python warnings and a CI build failure
- curl example in Authentication page was referencing the old `/api/player` endpoint which no longer exists

## Related Issue
#35 