### PR TITLE
feat: replace static API key auth with DB lookup

### DIFF
--- a/all_requirements_installer.sh
+++ b/all_requirements_installer.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# ============================================================
+#  PPA-DUN API Project - Dependency Installer
+#  Usage: bash install.sh
+#  Run this from the project root directory.
+# ============================================================
+
+# --- Color codes for output ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+PASS=0
+FAIL=0
+
+echo ""
+echo -e "${BLUE}======================================${NC}"
+echo -e "${BLUE}   PPA-DUN Dependency Installer       ${NC}"
+echo -e "${BLUE}======================================${NC}"
+echo ""
+
+# -----------------------------------------------
+# HELPER: print section header
+# -----------------------------------------------
+section() {
+    echo ""
+    echo -e "${YELLOW}--------------------------------------${NC}"
+    echo -e "${YELLOW}  $1${NC}"
+    echo -e "${YELLOW}--------------------------------------${NC}"
+}
+
+# -----------------------------------------------
+# HELPER: print result
+# -----------------------------------------------
+ok()   { echo -e "  ${GREEN}[OK]${NC}    $1"; PASS=$((PASS+1)); }
+fail() { echo -e "  ${RED}[FAIL]${NC}  $1"; FAIL=$((FAIL+1)); }
+skip() { echo -e "  ${YELLOW}[SKIP]${NC}  $1"; }
+
+# -----------------------------------------------
+# 1. API — Python (api/requirements.txt)
+# -----------------------------------------------
+section "API  |  Python packages  (api/requirements.txt)"
+
+if [ ! -f "api/requirements.txt" ]; then
+    skip "api/requirements.txt not found — skipping"
+else
+    # Check that python / pip exist
+    if ! command -v python &>/dev/null && ! command -v python3 &>/dev/null; then
+        fail "Python is not installed. Install Python 3.9+ and re-run."
+    else
+        PY=$(command -v python3 || command -v python)
+        PIP=$(command -v pip3 || command -v pip)
+
+        echo "  Using: $PY  |  $PIP"
+        echo ""
+
+        $PIP install -r api/requirements.txt
+
+        if [ $? -eq 0 ]; then
+            ok "api/requirements.txt installed successfully"
+        else
+            fail "api/requirements.txt installation failed"
+        fi
+    fi
+fi
+
+# -----------------------------------------------
+# 2. Backend — Python (backend/requirements.txt)
+# -----------------------------------------------
+section "Backend  |  Python packages  (backend/requirements.txt)"
+
+if [ ! -f "backend/requirements.txt" ]; then
+    skip "backend/requirements.txt not found — skipping"
+else
+    if ! command -v python &>/dev/null && ! command -v python3 &>/dev/null; then
+        fail "Python is not installed. Install Python 3.9+ and re-run."
+    else
+        PIP=$(command -v pip3 || command -v pip)
+
+        $PIP install -r backend/requirements.txt
+
+        if [ $? -eq 0 ]; then
+            ok "backend/requirements.txt installed successfully"
+        else
+            fail "backend/requirements.txt installation failed"
+        fi
+    fi
+fi
+
+# -----------------------------------------------
+# 3. Frontend — Node.js (frontend/package.json)
+# -----------------------------------------------
+section "Frontend  |  Node packages  (frontend/package.json)"
+
+if [ ! -f "frontend/package.json" ]; then
+    skip "frontend/package.json not found — skipping"
+else
+    if ! command -v node &>/dev/null; then
+        fail "Node.js is not installed. Install Node.js 18+ and re-run."
+    elif ! command -v npm &>/dev/null; then
+        fail "npm is not installed. It usually comes with Node.js."
+    else
+        echo "  Using: $(node -v)  |  npm $(npm -v)"
+        echo ""
+
+        cd frontend
+        npm install
+        RESULT=$?
+        cd ..
+
+        if [ $RESULT -eq 0 ]; then
+            ok "frontend/package.json installed successfully"
+        else
+            fail "frontend/package.json installation failed"
+        fi
+    fi
+fi
+
+# -----------------------------------------------
+# 4. Summary
+# -----------------------------------------------
+echo ""
+echo -e "${BLUE}======================================${NC}"
+echo -e "${BLUE}  Installation Summary                ${NC}"
+echo -e "${BLUE}======================================${NC}"
+echo -e "  ${GREEN}Passed : $PASS${NC}"
+echo -e "  ${RED}Failed : $FAIL${NC}"
+echo ""
+
+if [ $FAIL -eq 0 ]; then
+    echo -e "${GREEN}  All dependencies installed. Ready to run!${NC}"
+else
+    echo -e "${RED}  Some installations failed. Check the errors above.${NC}"
+    exit 1
+fi
+
+echo ""

--- a/api/main.py
+++ b/api/main.py
@@ -1,29 +1,43 @@
+import os
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-import os
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from dotenv import load_dotenv
 from api.routers import player
 from api.services.player import compute_player_value, compute_recommended_bid
 from api.models.player import PlayerValueRequest, PlayerBidRequest
-from dotenv import load_dotenv
 
 load_dotenv()
 
+# ── Database ─────────────────────────────────────────────────────────────────
+
+DATABASE_URL = "mysql+pymysql://root:{password}@db:3306/{db}".format(
+    password=os.getenv("MYSQL_ROOT_PASSWORD", ""),
+    db=os.getenv("MYSQL_DATABASE", "ppa_dun_api"),
+)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+# ── App ───────────────────────────────────────────────────────────────────────
+
 app = FastAPI(title="PPA-DUN API")
-API_KEY = os.getenv("API_KEY")
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-      "http://localhost:5173",       # local development                                                                                        
-      "http://dev.ppa-dun.site",     # dev                                                                                              
-      "https://ppa-dun.site",        # prod                                                                                   
+        "http://localhost:5173",       # local development
+        "http://dev.ppa-dun.site",     # dev
+        "https://ppa-dun.site",        # prod
     ],
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+# ── Middleware ────────────────────────────────────────────────────────────────
 
 @app.middleware("http")
 async def verify_api_key(request: Request, call_next):
@@ -37,35 +51,53 @@ async def verify_api_key(request: Request, call_next):
             status_code=401,
             content={"detail": "Missing API key"}
         )
-    if api_key != API_KEY:
+
+    # Look up the key in the database
+    try:
+        db = SessionLocal()
+        result = db.execute(
+            text("SELECT id FROM api_keys WHERE key = :key"),
+            {"key": api_key}
+        ).fetchone()
+        db.close()
+    except Exception:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "Service unavailable"}
+        )
+
+    if result is None:
         return JSONResponse(
             status_code=401,
             content={"detail": "Invalid API key"}
         )
+
     return await call_next(request)
 
+# ── Exception Handlers ────────────────────────────────────────────────────────
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    # Extract only the field names that are missing or invalid
     missing_fields = [".".join(str(loc) for loc in err["loc"] if loc != "body") for err in exc.errors()]
     return JSONResponse(
         status_code=422,
         content={"detail": f"Missing fields: {', '.join(missing_fields)}"},
     )
 
+# ── Routers ───────────────────────────────────────────────────────────────────
 
 app.include_router(player.router)
 
+# ── Health ────────────────────────────────────────────────────────────────────
 
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
 
-
-# Demo endpoints — no API key required, intended for public dashboard demo only.
-# These call the same service functions as /player/value and /player/bid,
-# but are exposed without authentication so the key is never sent to the browser.
+# ── Demo Endpoints ────────────────────────────────────────────────────────────
+# No API key required. Calls the same service functions as /player/value and
+# /player/bid, but exposed without authentication so the key is never sent
+# to the browser.
 
 @app.post("/demo/value")
 def demo_value(request: PlayerValueRequest):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,5 @@ fastapi==0.115.0
 uvicorn==0.30.6
 python-dotenv==1.0.1
 pydantic==2.9.2
+sqlalchemy==2.0.36
+pymysql==1.1.1


### PR DESCRIPTION
## What
- `api/requirements.txt` — Added `sqlalchemy==2.0.36` and `pymysql==1.1.1`
- `api/main.py` — Replaced static API key comparison with live DB lookup against `api_keys` table

## Why
Previously, the API server validated requests by comparing `X-API-Key` against a single hardcoded value in `.env`. This meant API keys issued by the backend and stored in the `api_keys` table could never actually be used to make API calls.

Now the middleware queries the shared DB directly:
- Valid key (exists in `api_keys`) → request passes through
- Invalid key → 401
- DB connection failure → 503
- `/health`, `/demo/*`, `OPTIONS` → always exempt, no DB query

## Notes
- DB connection is inlined in `main.py` using `MYSQL_ROOT_PASSWORD` and `MYSQL_DATABASE` env vars (managed by DevOps on the server)
- Local development: `/demo/*` endpoints remain fully testable without DB
- Full verification (valid key → 200, invalid key → 401) to be confirmed after deploy

## Related Issue
#34 