### PR TITLE
filter added for pitcher

### DIFF
--- a/backend/data/depth_charts.py
+++ b/backend/data/depth_charts.py
@@ -76,12 +76,17 @@ def _scrape_team(slug: str) -> list[dict]:
         if row.find(["td", "th"])
     ]
 
+    PITCHER_POSITIONS = {"P", "RP", "CL"}
+
     rows = []
     for row_idx, tr in enumerate(data_table.find_all("tr")[1:]):
         if row_idx >= len(positions):
             break
-
         position = positions[row_idx]
+
+        # Skip pitchers — players tables contain batters only
+        if position in PITCHER_POSITIONS:
+            continue
 
         for depth_order, td in enumerate(tr.find_all("td"), start=1):
             link = td.find("a", href=True)


### PR DESCRIPTION
## Bug fix during testing

depth_charts.py initially scraped pitcher positions (P, RP, CL) alongside batters.
Since players_al and players_nl contain batters only, pitcher names caused unmatched
UPDATE attempts, resulting in only 24 matched rows out of 364.
Added PITCHER_POSITIONS filter in _scrape_team() to skip pitcher rows entirely.
After fix: AL 201 matched, NL 181 matched.

---

### Known issues / follow-up required

The following must be addressed when the algorithm update issue is processed:

1. Remove the POST /player/recalculate stub endpoint from api/routers/player.py.
2. In backend/data/daily_update.py _step_recalculate(), replace the URL pointed to by
   API_RECALCULATE_URL (currently the stub /player/recalculate) with the real
   player_value algorithm endpoint once it is finalized.

## Related Issue
#69 
