### PR TITLE
Hard coded Baseline value replaced with computed value

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -10,8 +10,12 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from api.routers import player, players_data
-from api.services.player import compute_player_value, compute_recommended_bid
+from api.services.player import compute_player_value, compute_recommended_bid, reload_baselines
 from api.models.player import PlayerValueRequest, PlayerBidRequest
+from pydantic import BaseModel
+
+import logging
+logging.basicConfig(level=logging.INFO)
 
 # Load environment variables from .env file (MYSQL_ROOT_PASSWORD, MYSQL_HOST, etc.)
 load_dotenv()
@@ -110,6 +114,7 @@ async def verify_api_key(request: Request, call_next):
     if (
         request.url.path == "/health"
         or request.url.path.startswith("/demo")
+        or request.url.path.startswith("/internal")   # internal endpoints: no API key required
         or request.url.path == "/player/recalculate" # must be deleted after "FEAT-12" is done
         or request.method == "OPTIONS"
     ):
@@ -202,3 +207,22 @@ def demo_bid(request: Request, body: PlayerBidRequest):
     """
     check_demo_origin(request)
     return compute_recommended_bid(body)
+
+# ── Internal Baseline Reload ──────────────────────────────────────────────────
+# Called by backend/data/compute_baselines.py after each daily baseline
+# computation. Updates the in-memory cache in api/services/player.py.
+# This endpoint is internal-only: it is auth-exempt in the middleware above,
+# but should only be reachable within the Docker Compose network.
+
+class BaselinePayload(BaseModel):
+    batter:  dict
+    pitcher: dict
+
+@app.post("/internal/reload-baselines")
+def internal_reload_baselines(payload: BaselinePayload):
+    """
+    Receive newly computed league baselines from the backend server
+    and update the in-memory cache used for z-score calculation.
+    """
+    reload_baselines(payload.batter, payload.pitcher)
+    return {"status": "ok"}

--- a/api/services/player.py
+++ b/api/services/player.py
@@ -9,19 +9,17 @@ from api.models.player import (
     PitcherStats,
 )
 
-# ── League Baseline Constants (Roto 5x5 standard) ────────────────────────────
-# Mean and standard deviation of each scoring category across a typical
-# 12-team Roto 5x5 fantasy-relevant player pool.
-#
-# Used to compute z-scores:  z = (player_stat - mean) / std
-#
-# A player exactly at league average scores z = 0.
-# A player one standard deviation above average scores z = 1.
-#
-# Source: derived from historical MLB fantasy league data.
-# Clients do not need to provide these — they are internal constants.
+import logging
+import threading
 
-BATTER_BASELINES = {
+logger = logging.getLogger(__name__)
+
+# ── Fallback Baseline Constants ───────────────────────────────────────────────
+# Used only when the in-memory cache has not yet been populated by a push
+# from the backend server (i.e., before the first daily_update run).
+# Do NOT use these directly in algorithm logic — always call get_baselines().
+
+_BATTER_BASELINES_FALLBACK = {
     "R":   {"mean": 75.0,  "std": 20.0},
     "HR":  {"mean": 18.0,  "std": 10.0},
     "RBI": {"mean": 72.0,  "std": 20.0},
@@ -29,13 +27,54 @@ BATTER_BASELINES = {
     "AVG": {"mean": 0.260, "std": 0.025},
 }
 
-PITCHER_BASELINES = {
+_PITCHER_BASELINES_FALLBACK = {
     "W":    {"mean": 10.0,  "std": 4.0},
-    "SV":   {"mean": 10.0,  "std": 14.0},   # High std: closers skew the pool
+    "SV":   {"mean": 10.0,  "std": 14.0},
     "K":    {"mean": 130.0, "std": 50.0},
     "ERA":  {"mean": 4.00,  "std": 0.70},
     "WHIP": {"mean": 1.25,  "std": 0.15},
 }
+
+# ── In-memory baseline cache ──────────────────────────────────────────────────
+# Populated by POST /internal/reload-baselines (called from daily_update.py).
+# _baseline_lock ensures thread-safe writes since FastAPI may handle
+# concurrent requests across multiple threads.
+
+_baseline_lock  = threading.Lock()
+_batter_baselines:  dict = {}   # empty = not yet loaded; fallback will be used
+_pitcher_baselines: dict = {}
+
+
+def reload_baselines(batter: dict, pitcher: dict) -> None:
+    """
+    Replace the in-memory baseline cache with newly computed values.
+    Called by POST /internal/reload-baselines in api/main.py.
+    Thread-safe via _baseline_lock.
+    """
+    global _batter_baselines, _pitcher_baselines
+    with _baseline_lock:
+        _batter_baselines  = batter
+        _pitcher_baselines = pitcher
+    logger.info("[baselines] cache updated")
+
+
+def get_baselines(player_type: str) -> dict:
+    """
+    Return the current baseline dict for the given player_type.
+    Falls back to hardcoded constants if the cache is empty,
+    and logs a warning so the condition is visible in server logs.
+    """
+    with _baseline_lock:
+        if player_type == "batter":
+            if _batter_baselines:
+                return _batter_baselines
+            logger.warning("[baselines] batter cache empty — using fallback constants")
+            return _BATTER_BASELINES_FALLBACK
+        else:
+            if _pitcher_baselines:
+                return _pitcher_baselines
+            logger.warning("[baselines] pitcher cache empty — using fallback constants")
+            return _PITCHER_BASELINES_FALLBACK
 
 # ── Normalization Ceilings ────────────────────────────────────────────────────
 # Z_MAX_* = approximate z_total of an all-time elite player in a single season.
@@ -256,7 +295,7 @@ def _compute_z_scores(blended: dict[str, float], player_type: str) -> float:
     Returns z_total.
     """
     if player_type == "batter":
-        b = BATTER_BASELINES
+        b = get_baselines("batter")
         return (
             _zscore(blended["R"],   b["R"]["mean"],   b["R"]["std"])
             + _zscore(blended["HR"],  b["HR"]["mean"],  b["HR"]["std"])
@@ -265,7 +304,7 @@ def _compute_z_scores(blended: dict[str, float], player_type: str) -> float:
             + _zscore(blended["AVG"], b["AVG"]["mean"], b["AVG"]["std"])
         )
     else:
-        p = PITCHER_BASELINES
+        p = get_baselines("pitcher")
         return (
             _zscore(blended["W"],    p["W"]["mean"],    p["W"]["std"])
             + _zscore(blended["SV"],   p["SV"]["mean"],   p["SV"]["std"])

--- a/backend/data/daily_update.py
+++ b/backend/data/daily_update.py
@@ -33,6 +33,18 @@ API_RECALCULATE_URL = os.getenv(
 )
 
 
+# ── Step 0: Compute league baselines ─────────────────────────────────────────
+
+def _step_baselines() -> None:
+    from data.compute_baselines import compute_and_store, push_to_api
+    db = SessionLocal()
+    try:
+        baselines = compute_and_store(db)
+    finally:
+        db.close()
+    push_to_api(baselines)
+
+
 # ── Step 1: Injuries ──────────────────────────────────────────────────────────
 
 def _step_injuries() -> None:
@@ -149,6 +161,7 @@ def _step_recalculate() -> None:
 def run_daily_update() -> None:
     """
     Run the full daily pipeline:
+      Step 0 — Compute league baselines and push to api server
       Step 1 — Fetch and apply injury data
       Step 2 — Fetch and apply depth chart data
       Step 3 — Recalculate player_value for all players
@@ -157,6 +170,15 @@ def run_daily_update() -> None:
     start   = datetime.now()
     results = {}
     logger.info("=== Daily update started ===")
+
+    # Step 0: Baselines
+    try:
+        logger.info("[0/3] Computing league baselines...")
+        _step_baselines()
+        results["baselines"] = "OK"
+    except Exception as e:
+        logger.error(f"[0/3] Baselines failed: {e}")
+        results["baselines"] = f"FAILED: {e}"
 
     # Step 1: Injuries
     try:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Float, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, Float, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
 from datetime import datetime
 from db.session import Base  # Base is defined in db/session.py via declarative_base()
@@ -168,3 +168,31 @@ class UnmatchedPlayer(Base):
     sb         = Column(Integer,     nullable=True)
     avg        = Column(Float,       nullable=True)
     created_at = Column(DateTime,    default=datetime.utcnow)
+
+
+# ── LeagueBaseline ────────────────────────────────────────────────────────────
+# Stores per-category mean and std computed from the actual player pool.
+# Used by api/services/player.py as the baseline for z-score calculation.
+#
+# Rows are identified by (player_type, category) — this pair acts as a
+# logical unique key and is the target for upsert operations in
+# compute_baselines.py.
+#
+# player_type : "batter" or "pitcher"
+# category    : stat name — batter: R, HR, RBI, SB, AVG
+#                           pitcher: W, SV, K, ERA, WHIP
+# mean / std  : computed from non-NULL rows in players_al + players_nl
+# computed_at : UTC timestamp of the last successful computation
+
+class LeagueBaseline(Base):
+    __tablename__ = "league_baselines"
+    __table_args__ = (
+        UniqueConstraint("player_type", "category", name="uq_baseline_type_category"),
+    )
+
+    id          = Column(Integer,  primary_key=True, index=True)
+    player_type = Column(String(10),  nullable=False)   # "batter" or "pitcher"
+    category    = Column(String(10),  nullable=False)   # e.g. "HR", "ERA"
+    mean        = Column(Float,       nullable=False)
+    std         = Column(Float,       nullable=False)
+    computed_at = Column(DateTime,    nullable=False)


### PR DESCRIPTION
## Summary
Replaced hardcoded `BATTER_BASELINES` / `PITCHER_BASELINES` constants in
`api/services/player.py` with a dynamic in-memory cache populated by the
backend server after each daily update run.

## Changes Made

**`backend/db/models.py`**
- Added `LeagueBaseline` model with `(player_type, category)` unique constraint
- Added `UniqueConstraint` to SQLAlchemy imports

**`backend/data/compute_baselines.py`** (new file)
- Computes mean/std for batter categories (R, HR, RBI, SB, AVG) from
  `players_al` + `players_nl`
- Upserts results into `league_baselines` via `ON DUPLICATE KEY UPDATE`
- POSTs computed baselines to `api/internal/reload-baselines`

**`backend/data/daily_update.py`**
- Added `_step_baselines()` as Step 0 in the daily pipeline
- Step 0 runs before Step 3 (player_value recalculation)

**`api/services/player.py`**
- Renamed constants to `_BATTER_BASELINES_FALLBACK` / `_PITCHER_BASELINES_FALLBACK`
- Added thread-safe in-memory cache (`_batter_baselines`, `_pitcher_baselines`)
- Added `reload_baselines()` and `get_baselines()` functions
- `_compute_z_scores()` now calls `get_baselines()` instead of referencing
  constants directly

**`api/main.py`**
- Added `POST /internal/reload-baselines` endpoint
- Added `/internal/*` to auth middleware exempt paths
- Added `BaselinePayload` Pydantic model
- Added `logging.basicConfig(level=logging.INFO)`

## Test Results (local Docker)
- `compute_and_store()` successfully computed batter baselines from DB
- `league_baselines` table populated with 5 batter categories
- `POST /internal/reload-baselines` returned 200 OK
- `[baselines] cache updated` confirmed in api server logs
- Fallback warning logged before first push confirmed

## Deferred
- Pitcher baseline computation deferred to ALG-02b
- nginx `/internal/` path exposure to be verified separately

## Related Issue
#76 
