### PR TITLE
REFACTOR-01 · Rename players_* to batters_* across DB, models, and all references

### DIFF
--- a/api/routers/players_data.py
+++ b/api/routers/players_data.py
@@ -35,7 +35,7 @@ SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 # This prevents SQL injection through column name manipulation and limits
 # exposure of internal DB fields (e.g. player_id, first_name, team_id).
 
-ALLOWED_COLUMNS = {
+BATTER_ALLOWED_COLUMNS = {
     "name", "position", "team", "player_id",
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date", "bat_side", "pitch_hand",
@@ -45,7 +45,7 @@ ALLOWED_COLUMNS = {
 }
 
 # Ordered list for full detail response (ALLOWED_COLUMNS as sorted list)
-FULL_DETAIL_COLUMNS = [
+BATTER_FULL_DETAIL_COLUMNS = [
     "name", "position", "team", "player_id",
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date", "bat_side", "pitch_hand",
@@ -55,7 +55,7 @@ FULL_DETAIL_COLUMNS = [
 ]
 
 # Returned when the columns param is omitted
-BASIC_COLUMNS = [
+BATTER_BASIC_COLUMNS = [
     "name", "position", "team", "player_id",
     "ab", "r", "h", "single", "double", "triple",
     "hr", "rbi", "bb", "k", "sb", "cs", "avg", "obp", "slg",
@@ -99,7 +99,7 @@ def get_players(
 
     Returns all players in the specified league.
     - league is required. Returns 400 if missing or not AL/NL.
-    - columns is optional. Returns 400 if any column is not in ALLOWED_COLUMNS.
+    - columns is optional. Returns 400 if any column is not in BATTER_ALLOWED_COLUMNS.
     - If columns is omitted, returns name, position, team, player_value only.
     - name is always included in the response regardless of columns param.
     - Requires a valid X-API-Key header (enforced by middleware in api/main.py).
@@ -115,21 +115,21 @@ def get_players(
     # Resolve and validate requested columns
     if columns:
         requested = [c.strip().lower() for c in columns.split(",") if c.strip()]
-        invalid   = [c for c in requested if c not in ALLOWED_COLUMNS]
+        invalid = [c for c in requested if c not in BATTER_ALLOWED_COLUMNS]
         if invalid:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Invalid column(s): {', '.join(invalid)}. "
-                    f"Allowed columns: {', '.join(sorted(ALLOWED_COLUMNS))}"
+                    f"Allowed columns: {', '.join(sorted(BATTER_ALLOWED_COLUMNS))}"
                 ),
             )
         # Ensure name is always first, deduplicate while preserving order
         select_cols = list(dict.fromkeys(["name"] + requested))
     else:
-        select_cols = BASIC_COLUMNS
+        select_cols = BATTER_BASIC_COLUMNS
 
-    table      = "players_al" if league == "AL" else "players_nl"
+    table = "batters_al" if league == "AL" else "batters_nl"
     col_clause = ", ".join(f"`{c}`" for c in select_cols)
 
     db = SessionLocal()
@@ -163,7 +163,7 @@ def get_player(
     - detail=full    : returns all columns in ALLOWED_COLUMNS
     - Returns 400 if detail param is provided but not 'full'
     - Returns 404 if player_id is not found in either table.
-    - Searches players_al first, then players_nl as fallback.
+    - Searches batters_al first, then batters_nl as fallback.
     - Requires a valid X-API-Key header (enforced by middleware in api/main.py).
     """
     if detail is not None and detail.lower() != "full":
@@ -172,12 +172,12 @@ def get_player(
             detail="Invalid detail value. Use 'full' or omit the parameter.",
         )
 
-    select_cols = FULL_DETAIL_COLUMNS if detail and detail.lower() == "full" else BASIC_COLUMNS
+    select_cols = BATTER_FULL_DETAIL_COLUMNS if detail and detail.lower() == "full" else BATTER_BASIC_COLUMNS
     col_clause  = ", ".join(f"`{c}`" for c in select_cols)
 
     db = SessionLocal()
     try:
-        for table in ("players_al", "players_nl"):
+        for table in ("batters_al", "batters_nl"):
             row = db.execute(
                 text(f"""
                     SELECT {col_clause}
@@ -190,7 +190,7 @@ def get_player(
 
             if row:
                 return {
-                    "league":  "AL" if table == "players_al" else "NL",
+                    "league":  "AL" if table == "batters_al" else "NL",
                     "detail":  detail.lower() if detail else "basic",
                     "player":  _row_to_dict(row, select_cols),
                 }
@@ -230,7 +230,7 @@ def player_bid_by_name(request: PlayerBidByNameRequest):
     POST /player/bid/name
 
     Accepts player_id, league_context, and draft_context.
-    Fetches player stats from DB (players_al then players_nl),
+    Fetches player stats from DB (batters_al then batters_nl),
     uses stored player_value, and returns recommended_bid.
 
     - Returns 404 if player_id is not found in either table.
@@ -245,7 +245,7 @@ def player_bid_by_name(request: PlayerBidByNameRequest):
     row = None
     league = None
     try:
-        for table, lg in (("players_al", "AL"), ("players_nl", "NL")):
+        for table, lg in (("batters_al", "AL"), ("batters_nl", "NL")):
             row = db.execute(
                 text(f"""
                     SELECT {col_clause}

--- a/backend/data/compute_baselines.py
+++ b/backend/data/compute_baselines.py
@@ -54,7 +54,7 @@ def _compute_mean_std(values: list[float]) -> tuple[float, float] | None:
 
 def compute_and_store(db: Session) -> dict:
     """
-    Compute batter league baselines from players_al and players_nl,
+    Compute batter league baselines from batters_al and batters_nl,
     upsert results into the league_baselines table, and return the
     computed values as a dict to be POSTed to the api server.
 
@@ -73,8 +73,8 @@ def compute_and_store(db: Session) -> dict:
     for col, stat_key in BATTER_COLUMN_TO_STAT.items():
         # Collect non-NULL values from both AL and NL tables
         values = (
-            _fetch_column(db, "players_al", col)
-            + _fetch_column(db, "players_nl", col)
+            _fetch_column(db, "batters_al", col)
+            + _fetch_column(db, "batters_nl", col)
         )
 
         computed = _compute_mean_std(values)

--- a/backend/data/daily_update.py
+++ b/backend/data/daily_update.py
@@ -66,7 +66,6 @@ def _step_depth_charts() -> None:
 def _fetch_all_players(db, table: str) -> list[dict]:
     """
     Fetch all batter rows needed for FVARz recalculation.
-    Pitcher stats columns not yet in DB (pending ALG-02b) — pitchers skipped.
     """
     rows = db.execute(
         text(f"""
@@ -189,13 +188,12 @@ def _step_recalculate() -> None:
     """
     Fetch all players from both tables, compute player_value using FVARz,
     and write the result back to the DB.
-    Pitchers are skipped until pitcher stat columns are added (ALG-02b).
     """
     db = SessionLocal()
     try:
         players = (
-            _fetch_all_players(db, "players_al")
-            + _fetch_all_players(db, "players_nl")
+            _fetch_all_players(db, "batters_al")
+            + _fetch_all_players(db, "batters_nl")
         )
     finally:
         db.close()

--- a/backend/data/depth_charts.py
+++ b/backend/data/depth_charts.py
@@ -32,7 +32,7 @@ HEADERS = {
 BASE_URL = "https://www.espn.com/mlb/team/depth/_/name/{slug}"
 
 # (ESPN slug, league)
-# League determines which table (players_al or players_nl) to update first
+# League determines which table (batters_al or batters_nl) to update first
 TEAMS = [
     # AL
     ("bal",  "AL"), ("bos",  "AL"), ("nyy",  "AL"), ("tb",   "AL"), ("tor",  "AL"),
@@ -84,7 +84,7 @@ def _scrape_team(slug: str) -> list[dict]:
             break
         position = positions[row_idx]
 
-        # Skip pitchers — players tables contain batters only
+        # Skip pitchers — batter tables contain batters only
         if position in PITCHER_POSITIONS:
             continue
 
@@ -110,17 +110,17 @@ def _scrape_team(slug: str) -> list[dict]:
 
 def _update_players(rows: list[dict], league: str) -> tuple[int, int]:
     """
-    Update depth_order in the appropriate players table.
+    Update depth_order in the appropriate batters table.
 
     Strategy:
-      - Primary table  : players_al if league == "AL", else players_nl
+      - Primary table  : batters_al if league == "AL", else batters_nl
       - Fallback table : the other one (handles traded players)
     Match is done by normalize_name() applied to both sides at query time.
 
     Returns (matched_count, unmatched_count).
     """
-    primary  = "players_al" if league == "AL" else "players_nl"
-    fallback = "players_nl" if league == "AL" else "players_al"
+    primary  = "batters_al" if league == "AL" else "batters_nl"
+    fallback = "batters_nl" if league == "AL" else "batters_al"
 
     db      = SessionLocal()
     matched = 0
@@ -163,15 +163,15 @@ def _update_players(rows: list[dict], league: str) -> tuple[int, int]:
 
 def _reset_depth_order() -> None:
     """
-    Clear depth_order for both players tables before applying today's data.
+    Clear depth_order for both batters tables before applying today's data.
     Runs once per pipeline run so stale entries from yesterday do not persist,
     while allowing the 30-team loop to accumulate today's values without
     overwriting each other.
     """
     db = SessionLocal()
     try:
-        db.execute(text("UPDATE players_al SET depth_order = NULL"))
-        db.execute(text("UPDATE players_nl SET depth_order = NULL"))
+        db.execute(text("UPDATE batters_al SET depth_order = NULL"))
+        db.execute(text("UPDATE batters_nl SET depth_order = NULL"))
         db.commit()
     except Exception:
         db.rollback()
@@ -182,7 +182,7 @@ def _reset_depth_order() -> None:
 
 def fetch_and_update() -> None:
     """
-    Scrape ESPN depth charts for all 30 teams and update players tables.
+    Scrape ESPN depth charts for all 30 teams and update batters tables.
     Called by daily_update.py.
     """
     _reset_depth_order()

--- a/backend/data/init_players.py
+++ b/backend/data/init_players.py
@@ -1,6 +1,6 @@
 # backend/data/init_players.py
 #
-# One-time initialization script. Populates players_al and players_nl tables by:
+# One-time initialization script. Populates batters_al and batters_nl tables by:
 #   1. Fetching all 2025 MLB players from the MLB Stats API (statsapi.mlb.com)
 #   2. Parsing AL and NL season stats from local SQL dump files
 #   3. Matching each SQL dump row to an API player using (normalized_name, team)
@@ -21,7 +21,7 @@ load_dotenv()
 
 from sqlalchemy.orm import Session
 from db.session import SessionLocal, engine, Base
-from db.models import ALPlayer, NLPlayer, UnmatchedPlayer
+from db.models import ALBatter, NLBatter, UnmatchedPlayer
 from data.utils import normalize_name
 
 logging.basicConfig(
@@ -306,7 +306,7 @@ def parse_sql_dump(filepath: str, league: str) -> list[dict]:
 
 def _build_player_kwargs(row: dict, api_player: dict) -> dict:
     """
-    Build the keyword arguments dict shared by both ALPlayer and NLPlayer
+    Build the keyword arguments dict shared by both ALBatter and NLBatter
     constructors. Centralizes the field mapping so it is not duplicated.
     """
     return dict(
@@ -367,7 +367,7 @@ def insert_league(
 ) -> None:
     """
     Match SQL dump rows for one league to MLB API players and insert them
-    into the given ORM model class (ALPlayer or NLPlayer).
+    into the given ORM model class (ALBatter or NLBatter).
 
     Matching key: (normalize_name(name), team_abbr)
     Unmatched rows are logged to init_players_unmatched.log.
@@ -434,8 +434,8 @@ def run():
 
     db = SessionLocal()
     try:
-        insert_league(db, al_rows, api_lookup, ALPlayer, "AL")
-        insert_league(db, nl_rows, api_lookup, NLPlayer, "NL")
+        insert_league(db, al_rows, api_lookup, ALBatter, "AL")
+        insert_league(db, nl_rows, api_lookup, NLBatter, "NL")
     finally:
         db.close()
 

--- a/backend/data/injury.py
+++ b/backend/data/injury.py
@@ -142,13 +142,13 @@ def _fetch_from_html() -> list[dict]:
 
 def _reset_injury_status() -> None:
     """
-    Clear injury_status for all players before applying today's data.
+    Clear injury_status for all batters before applying today's data.
     Players not on today's injury report are considered healthy (NULL).
     """
     db = SessionLocal()
     try:
-        db.execute(text("UPDATE players_al SET injury_status = NULL"))
-        db.execute(text("UPDATE players_nl SET injury_status = NULL"))
+        db.execute(text("UPDATE batters_al SET injury_status = NULL"))
+        db.execute(text("UPDATE batters_nl SET injury_status = NULL"))
         db.commit()
     except Exception:
         db.rollback()
@@ -159,9 +159,9 @@ def _reset_injury_status() -> None:
 
 def _update_players(rows: list[dict]) -> tuple[int, int]:
     """
-    Update injury_status in players_al and players_nl.
+    Update injury_status in batters_al and batters_nl.
     Matches by normalize_name() applied to both sides at query time.
-    Tries players_al first, then players_nl as fallback (handles traded players).
+    Tries batters_al first, then batters_nl as fallback (handles traded players).
     Returns (matched_count, unmatched_count).
     """
     db      = SessionLocal()
@@ -173,7 +173,7 @@ def _update_players(rows: list[dict]) -> tuple[int, int]:
             status = row["injury_status"]
 
             updated = False
-            for table in ("players_al", "players_nl"):
+            for table in ("batters_al", "batters_nl"):
                 result = db.execute(
                     text(f"""
                         UPDATE {table}

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -47,10 +47,10 @@ class APIKey(Base):
     user = relationship("User", back_populates="api_keys")
 
 # ── PlayerBase ────────────────────────────────────────────────────────────────
-# Abstract mixin that defines the shared schema for ALPlayer and NLPlayer.
+# Abstract mixin that defines the shared schema for ALBatter and NLBatter.
 #
 # __abstract__ = True tells SQLAlchemy not to create a table for this class
-# itself. Only its concrete subclasses (ALPlayer, NLPlayer) get tables.
+# itself. Only its concrete subclasses (ALBatter, NLBatter) get tables.
 # declared_attr is required for columns that reference relationships or need
 # per-class customization; regular Column() definitions are inherited as-is.
 #
@@ -134,20 +134,20 @@ class PlayerBase:
     updated_at = Column(DateTime, nullable=True)
  
  
-# ── ALPlayer ──────────────────────────────────────────────────────────────────
+# ── ALBatter ──────────────────────────────────────────────────────────────────
 # American League batters. Populated from players_stats_al_2025.sql.
 # Queried when API requests specify league="AL".
+
+class ALBatter(PlayerBase, Base):
+    __tablename__ = "batters_al"
  
-class ALPlayer(PlayerBase, Base):
-    __tablename__ = "players_al"
  
- 
-# ── NLPlayer ──────────────────────────────────────────────────────────────────
+# ── NLBatter ──────────────────────────────────────────────────────────────────
 # National League batters. Populated from players_stats_nl_2025.sql.
 # Queried when API requests specify league="NL".
  
-class NLPlayer(PlayerBase, Base):
-    __tablename__ = "players_nl"
+class NLBatter(PlayerBase, Base):
+    __tablename__ = "batters_nl"
 
 
 # ── Unmatched ──────────────────────────────────────────────────────────────────
@@ -181,7 +181,7 @@ class UnmatchedPlayer(Base):
 # player_type : "batter" or "pitcher"
 # category    : stat name — batter: R, HR, RBI, SB, AVG
 #                           pitcher: W, SV, K, ERA, WHIP
-# mean / std  : computed from non-NULL rows in players_al + players_nl
+# mean / std  : computed from non-NULL rows in batters_al + batters_nl
 # computed_at : UTC timestamp of the last successful computation
 
 class LeagueBaseline(Base):


### PR DESCRIPTION
## What
Renamed players_al and players_nl tables to batters_al and batters_nl, and updated all references across the codebase:

ALPlayer → ALBatter, NLPlayer → NLBatter in backend/db/models.py
Table references updated in init_players.py, compute_baselines.py, daily_update.py, injury.py, depth_charts.py
ALLOWED_COLUMNS → BATTER_ALLOWED_COLUMNS, BASIC_COLUMNS → BATTER_BASIC_COLUMNS, FULL_DETAIL_COLUMNS → BATTER_FULL_DETAIL_COLUMNS in api/routers/players_data.py
Dropped old players_al / players_nl tables via SQL and re-initialized via init_players.py

## Why
players_al / players_nl naming became ambiguous once pitcher-specific tables (pitchers_al, pitchers_nl) were planned in FEAT-16. Renaming to batters_* before pitcher tables are introduced keeps the schema unambiguous and makes the separation between batter and pitcher data explicit throughout the codebase.

## Related Issue
#89 
