### PR TITLE
FEAT-20: Rename /player/bid/name to /player/bid/id and fix unmatched log overwrite

### DIFF
--- a/api/models/player.py
+++ b/api/models/player.py
@@ -163,7 +163,7 @@ class PlayerBidResponse(BaseModel):
 
 # ── player_name Based Bid Models ──────────────────────────────────────────────
 
-class PlayerBidByNameRequest(BaseModel):
+class PlayerBidByIdRequest(BaseModel):
     player_id:      int            # MLB stable integer player ID (replaces player_name)
     league_context: LeagueContext
     draft_context:  DraftContext
@@ -190,7 +190,7 @@ class PitcherStatsSnapshot(BaseModel):
     whip: float | None
 
 
-class PlayerBidByNameResponse(BaseModel):
+class PlayerBidByIdResponse(BaseModel):
     player_name:    str
     player_type:    str             # "batter" or "pitcher"
     position:       str

--- a/api/routers/players_data.py
+++ b/api/routers/players_data.py
@@ -1,6 +1,6 @@
 from api.models.player import (
-    PlayerBidByNameRequest,
-    PlayerBidByNameResponse,
+    PlayerBidByIdRequest,
+    PlayerBidByIdResponse,
     PlayerBidRequest,
     PlayerValueRequest,
     BatterStats,
@@ -381,10 +381,10 @@ PITCHER_BID_NAME_COLUMNS = [
 ]
 
 
-@router.post("/player/bid/name", response_model=PlayerBidByNameResponse)
-def player_bid_by_name(request: PlayerBidByNameRequest):
+@router.post("/player/bid/id", response_model=PlayerBidByIdResponse)
+def player_bid_by_id(request: PlayerBidByIdRequest):
     """
-    POST /player/bid/name
+    POST /player/bid/id
 
     Accepts player_id, league_context, and draft_context.
     Fetches player stats from DB — searches batters first, then pitchers.

--- a/backend/data/pipeline/init_players.py
+++ b/backend/data/pipeline/init_players.py
@@ -33,7 +33,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # File handler for unmatched rows
-unmatched_handler = logging.FileHandler("init_players_unmatched.log")
+unmatched_handler = logging.FileHandler("init_players_unmatched.log", mode="w")
 unmatched_handler.setLevel(logging.WARNING)
 unmatched_logger = logging.getLogger("unmatched")
 unmatched_logger.addHandler(unmatched_handler)


### PR DESCRIPTION
## What
- Renamed `/player/bid/name` endpoint to `/player/bid/id`
- Renamed model classes `PlayerBidByNameRequest` → `PlayerBidByIdRequest`, `PlayerBidByNameResponse` → `PlayerBidByIdResponse`
- Changed `init_players_unmatched.log` FileHandler mode from append to write (`mode='w'`)

## Why
The `/player/bid/name` endpoint identifies players by `player_id`, not by name, making the original path misleading.
The unmatched log was accumulating entries across runs due to default append mode, making it difficult to review results from the latest execution only.

## Related Issue
#99 
