### PR TITLE
Add clamp and guard code for abnormal input values in compute_recommended_bid()

### DIFF
--- a/api/services/player.py
+++ b/api/services/player.py
@@ -556,9 +556,9 @@ def compute_recommended_bid(request: PlayerBidRequest, player_value: float | Non
     # If my_roster is provided, derive remaining spots from roster_size - len(my_roster).
     # Otherwise, use the client-supplied my_remaining_roster_spots as-is.
     if dc.my_roster is not None:
-        my_remaining_roster_spots = lc.roster_size - len(dc.my_roster)
+        my_remaining_roster_spots = max(0, lc.roster_size - len(dc.my_roster))
     else:
-        my_remaining_roster_spots = dc.my_remaining_roster_spots
+        my_remaining_roster_spots = max(0, dc.my_remaining_roster_spots)
     min_reserve = max(0, my_remaining_roster_spots - 1)
     spendable   = max(1, dc.my_remaining_budget - min_reserve)
 
@@ -596,13 +596,13 @@ def compute_recommended_bid(request: PlayerBidRequest, player_value: float | Non
             )
 
         max_competitor_budget = max(
-            dc.opponent_budgets.get(name, 0) for name in competing_opponents
+            max(0, dc.opponent_budgets.get(name, 0)) for name in competing_opponents
         )
         # Ensure at least 1 to avoid clipping recommended_bid below minimum
         max_competitor_budget = max(1, max_competitor_budget)
 
     # Step 7: draft progress adjustment
-    draft_progress   = dc.drafted_players_count / (lc.league_size * lc.roster_size)
+    draft_progress   = min(1.0, dc.drafted_players_count / (lc.league_size * lc.roster_size))
     budget_ratio     = spendable / dc.my_remaining_budget if dc.my_remaining_budget > 0 else 0.5
     draft_multiplier = 1.0 + (budget_ratio - 0.5) * 0.2 * draft_progress
     draft_adj        = adjusted_price * draft_multiplier - adjusted_price


### PR DESCRIPTION
## What
- `my_remaining_roster_spots`: applied `max(0, ...)` clamp for both
  `my_roster`-derived and client-supplied values
- `lc.roster_size - len(dc.my_roster)`: applied `max(0, ...)` clamp
  to prevent negative remaining spots when my_roster exceeds roster_size
- `draft_progress`: applied `min(1.0, ...)` clamp to prevent values
  exceeding 1.0 when drafted_players_count exceeds league_size * roster_size
- `opponent_budgets`: applied `max(0, ...)` clamp on each value to
  prevent negative budgets from producing incorrect results

## Why
The following edge cases were not defended against and could produce
incorrect calculation results:
- my_remaining_roster_spots = 0 caused min_reserve calculation error
- len(dc.my_roster) exceeding lc.roster_size produced negative remaining spots
- drafted_players_count exceeding league_size * roster_size caused draft_progress > 1.0
- Negative values in opponent_budgets produced incorrect bid results

## Test Results
- my_remaining_roster_spots=0: 200 OK ✓
- my_roster length exceeding roster_size: 200 OK ✓
- drafted_players_count exceeding league_size * roster_size: 200 OK ✓
- Negative opponent_budgets: 200 OK ✓

## Related Issue
#104 
