### PR TITLE
Remove /player/recalculate stub endpoint and all related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ The `/demo/*` endpoints are open with a 10-req/min/IP cap so anyone can evaluate
 | `POST` | `/player/value`        | Compute player value (0–100)              | 🔒 |
 | `POST` | `/player/bid`          | Recommend auction bid in `$`              | 🔒 |
 | `POST` | `/player/bid/name`     | Bid by player name (auto-fetch stats)     | 🔒 |
-| `POST` | `/player/recalculate`  | Batch recalculate values                  | 🔒 |
 | `GET`  | `/players`             | List players (filterable)                 | 🔒 |
 | `GET`  | `/players/{id}`        | Single player details                     | 🔒 |
 | `POST` | `/demo/value`          | Same as `/player/value`, no key           | 10/min |

--- a/api/main.py
+++ b/api/main.py
@@ -119,7 +119,6 @@ async def verify_api_key(request: Request, call_next):
         request.url.path == "/health"
         or request.url.path.startswith("/demo")
         or request.url.path.startswith("/internal")   # internal endpoints: no API key required
-        or request.url.path == "/player/recalculate" # must be deleted after "FEAT-12" is done
         or request.url.path == "/docs"               # FastAPI auto-generated Swagger UI
         or request.url.path == "/redoc"              # FastAPI auto-generated ReDoc
         or request.url.path == "/openapi.json"       # OpenAPI schema (consumed by /docs and /redoc)

--- a/api/routers/player.py
+++ b/api/routers/player.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter
-from pydantic import BaseModel
 from api.models.player import (
     PlayerValueRequest,
     PlayerValueResponse,
@@ -63,73 +62,3 @@ def player_bid(request: PlayerBidRequest):
       opponent_budgets          : optional — used for competitor budget cap (ALG-04)
     """
     return compute_recommended_bid(request)
-
-
-# ── Stub: player_value recalculation ─────────────────────────────────────────
-# Temporary endpoint used by daily_update.py to recalculate player_value
-# for all players after injury / depth chart data is refreshed.
-#
-# This stub encodes player state into a 5-digit integer:
-#   Digits 1-3 : AB (zero-padded to 3 digits, capped at 999)
-#   Digit  4   : injury status label (0-9, see INJURY_LABEL below)
-#   Digit  5   : depth_order (capped at 9; 0 if not on depth chart)
-#
-# This encoding will be replaced by the real FVARz algorithm once finalized.
-# Auth is NOT required — this endpoint is called internally by the backend,
-# not exposed to external API consumers. It is exempt via the middleware
-# INTERNAL_PATHS list in api/main.py.
-
-INJURY_LABEL = {
-    None:           0,
-    "Day-To-Day":   1,
-    "10-Day IL":    2,
-    "15-Day IL":    3,
-    "60-Day IL":    4,
-    "Out":          5,
-    "7-Day IL":     6,
-    "Suspension":   7,
-    "Bereavement":  8,
-    "Paternity":    9,
-}
-
-
-class RecalculateRequest(BaseModel):
-    player_id:     int
-    player_type:   str            # "batter" or "pitcher"
-    ab:            int | None     # At Bats (batters only; None for pitchers)
-    injury_status: str | None     # Raw ESPN status string, or None if healthy
-    depth_order:   int | None     # 1 = starter; None if not on depth chart
-
-
-class RecalculateResponse(BaseModel):
-    player_id:    int
-    player_value: int             # 5-digit encoded integer (stub)
-
-
-@router.post("/player/recalculate", response_model=RecalculateResponse)
-def player_recalculate(request: RecalculateRequest):
-    """
-    POST /player/recalculate  [STUB — internal use only]
-
-    Encodes player state as a 5-digit integer player_value.
-    Called by daily_update.py after injury / depth chart refresh.
-    Will be replaced by the real FVARz algorithm once finalized.
-
-    Encoding:
-      player_value = AB(3 digits) + injury_label(1 digit) + depth_order(1 digit)
-
-    Examples:
-      AB=534, injury=None,        depth=2  →  53402
-      AB=120, injury=Day-To-Day,  depth=1  →  12011
-      AB=89,  injury=15-Day IL,   depth=3  →  08933
-    """
-    ab          = min(request.ab or 0, 999)
-    inj_label   = INJURY_LABEL.get(request.injury_status, 0)
-    depth_digit = min(request.depth_order or 0, 9)
-
-    player_value = int(f"{ab:03d}{inj_label}{depth_digit}")
-
-    return RecalculateResponse(
-        player_id=request.player_id,
-        player_value=player_value,
-    )


### PR DESCRIPTION
## What
- `api/routers/player.py`: removed INJURY_LABEL constant, RecalculateRequest model,
  RecalculateResponse model, and @router.post("/player/recalculate") handler
- `api/routers/player.py`: removed unused pydantic.BaseModel import
- `api/main.py`: removed /player/recalculate from auth exemption list
- `README.md`: removed /player/recalculate row from endpoint table

## Why
daily_update.py already calls /player/value directly for player value
recalculation. The /player/recalculate endpoint was never called anywhere
and existed as dead code. Removing it reduces confusion and cleans up
the codebase.

## Test Results
- POST /player/recalculate: 404 Not Found ✓
- POST /player/value: 200 OK ✓
- POST /player/bid: 200 OK ✓

## Related Issue
#105 
