### PR TITLE
Replace Pydantic v1 class Config with v2 ConfigDict in UserResponse

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from google.oauth2 import id_token
 from google.auth.transport import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from db.session import get_db
 from db.models import User, APIKey
 
@@ -27,14 +27,11 @@ class GoogleLoginRequest(BaseModel):
 
 
 class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id:    int
     email: str
     name:  str
-
-    class Config:
-        # from_attributes=True allows Pydantic to read values directly from
-        # SQLAlchemy ORM objects (e.g., return user directly without .dict()).
-        from_attributes = True
 
 
 class APIKeyResponse(BaseModel):


### PR DESCRIPTION
## What
- `backend/routers/auth.py`: added ConfigDict to pydantic imports
- `backend/routers/auth.py`: removed class Config from UserResponse
- `backend/routers/auth.py`: added model_config = ConfigDict(from_attributes=True)
  to UserResponse

## Why
The project uses Pydantic v2 but UserResponse still used the v1 style
class Config. All models should be consistent with Pydantic v2 conventions.

## Test Results
- UserResponse.model_validate() with mock ORM object: PASS ✓
- Behavior identical to before the change confirmed

## Related Issue
#106 