### PR TITLE
Add X-Admin-Key authentication to POST /admin/update

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter
+import os
+from fastapi import APIRouter, Request, HTTPException
 from data.pipeline.daily_update import run_daily_update
 import threading
 
@@ -6,7 +7,7 @@ router = APIRouter(prefix="/admin")
 
 
 @router.post("/update")
-def trigger_update():
+def trigger_update(request: Request):
     """
     POST /admin/update
 
@@ -14,6 +15,14 @@ def trigger_update():
     (injury → depth charts → player_value recalculation)
     in a background thread so the HTTP response returns instantly.
     """
+    admin_secret = os.getenv("ADMIN_SECRET")
+    if not admin_secret:
+        raise HTTPException(status_code=503, detail="ADMIN_SECRET not configured")
+
+    x_admin_key = request.headers.get("X-Admin-Key")
+    if not x_admin_key or x_admin_key != admin_secret:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Admin-Key")
+
     thread = threading.Thread(target=run_daily_update, daemon=True)
     thread.start()
 


### PR DESCRIPTION
## What
- `backend/routers/admin.py`: added os, Request, HTTPException imports
- `backend/routers/admin.py`: added request: Request parameter to trigger_update()
- `backend/routers/admin.py`: added ADMIN_SECRET environment variable check (503 if not set)
- `backend/routers/admin.py`: added X-Admin-Key header validation (401 if missing or incorrect)
- `backend/.env`: added ADMIN_SECRET entry

## Why
The /admin/update endpoint had no authentication, allowing anyone to
trigger the daily update pipeline. Repeated calls could cause server
overload. X-Admin-Key header authentication against ADMIN_SECRET
environment variable restricts access to authorized callers only.

## Test Results
- Request without X-Admin-Key: 401 ✓
- Request with incorrect key: 401 ✓
- Request with correct key: 200 update started ✓
- ADMIN_SECRET not configured: 503 ✓

## Related Issue
#107 
