### PR TITLE
feat: 15-min scheduler split + POST /admin/player-event for notifications

### DIFF
--- a/backend/data/pipeline/daily_update.py
+++ b/backend/data/pipeline/daily_update.py
@@ -308,9 +308,43 @@ def run_daily_update() -> None:
 
 # ── Scheduler ─────────────────────────────────────────────────────────────────
 
+def _external_fetch_cycle() -> None:
+    """Lightweight fetch loop that runs every 15 min — only injuries + depth charts.
+    These are cheap external HTTP calls and the data drives the user-facing
+    notification system, so we want low-latency propagation."""
+    logger.info("=== External fetch cycle started ===")
+    try:
+        _step_injuries()
+    except Exception as e:
+        logger.error(f"[external_fetch] injuries failed: {e}")
+    try:
+        _step_depth_charts()
+    except Exception as e:
+        logger.error(f"[external_fetch] depth_charts failed: {e}")
+    logger.info("=== External fetch cycle finished ===")
+
+
+def _full_recalc_cycle() -> None:
+    """Heavy recalc loop that runs once daily at 3 AM ET — baselines +
+    player_value across all ~1300 players. Kept on the original daily cadence
+    to avoid CPU thrash and external API load."""
+    logger.info("=== Full recalc cycle started ===")
+    try:
+        _step_baselines()
+    except Exception as e:
+        logger.error(f"[full_recalc] baselines failed: {e}")
+    try:
+        _step_recalculate()
+    except Exception as e:
+        logger.error(f"[full_recalc] player_value recalc failed: {e}")
+    logger.info("=== Full recalc cycle finished ===")
+
+
 def start_scheduler():
     """
-    Start a background scheduler that runs run_daily_update() at 3:00 AM ET daily.
+    Start a background scheduler with two jobs:
+      - external_fetch: every 15 min (injuries + depth charts)
+      - full_recalc:    daily at 3 AM ET (baselines + player_value recalc)
     Returns the scheduler instance so the caller can shut it down on app exit.
     Called from backend/main.py lifespan event.
     """
@@ -323,13 +357,19 @@ def start_scheduler():
 
     scheduler = BackgroundScheduler()
     scheduler.add_job(
-        run_daily_update,
+        _external_fetch_cycle,
+        trigger=CronTrigger(minute="*/15"),
+        id="external_fetch",
+        name="External fetch — injuries + depth (every 15 min)",
+    )
+    scheduler.add_job(
+        _full_recalc_cycle,
         trigger=CronTrigger(hour=3, minute=0, timezone="America/New_York"),
-        id="daily_update",
-        name="Daily MLB data update — 3AM ET",
+        id="full_recalc",
+        name="Full recalc — baselines + player_value (3AM ET daily)",
     )
     scheduler.start()
-    logger.info("Scheduler started — daily_update runs at 3:00 AM ET")
+    logger.info("Scheduler started — external_fetch every 15 min, full_recalc at 3AM ET")
     return scheduler
 
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,9 +1,24 @@
 import os
-from fastapi import APIRouter, Request, HTTPException
-from data.pipeline.daily_update import run_daily_update
 import threading
+from typing import Optional
+
+import requests
+from fastapi import APIRouter, Request, HTTPException
+from pydantic import BaseModel
+
+from data.pipeline.daily_update import run_daily_update
 
 router = APIRouter(prefix="/admin")
+
+
+class PlayerEventPayload(BaseModel):
+    """Fake notification payload — admin manually triggers a notification-worthy
+    event. No player data is mutated; this just relays the event to the Draft
+    Kit Backend so a toast appears in connected browsers."""
+    player_id: str
+    message: str
+    event_type: str = "INJURY"
+    player_name: Optional[str] = None
 
 
 @router.post("/update")
@@ -27,3 +42,42 @@ def trigger_update(request: Request):
     thread.start()
 
     return {"status": "update started"}
+
+
+@router.post("/player-event")
+def force_player_event(payload: PlayerEventPayload, request: Request):
+    """
+    POST /admin/player-event
+
+    Force-push a notification-worthy event to the Draft Kit (fake demo input).
+    No player data is mutated — this just relays the event to the Draft Kit
+    Backend webhook so a toast appears in connected browsers.
+
+    Body: { player_id, message, event_type?, player_name? }
+    Auth: X-Admin-Key header (must match ADMIN_SECRET env)
+    """
+    admin_secret = os.getenv("ADMIN_SECRET")
+    if not admin_secret:
+        raise HTTPException(status_code=503, detail="ADMIN_SECRET not configured")
+
+    x_admin_key = request.headers.get("X-Admin-Key")
+    if not x_admin_key or x_admin_key != admin_secret:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Admin-Key")
+
+    be_webhook_url = os.getenv("BE_WEBHOOK_URL")
+    internal_key = os.getenv("INTERNAL_WEBHOOK_KEY")
+    if not be_webhook_url or not internal_key:
+        raise HTTPException(status_code=503, detail="BE webhook not configured")
+
+    try:
+        resp = requests.post(
+            be_webhook_url,
+            json=payload.model_dump(),
+            headers={"X-Internal-Key": internal_key},
+            timeout=5,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=502, detail=f"Failed to notify backend: {e}")
+
+    return {"status": "notified", "event": payload.model_dump()}


### PR DESCRIPTION
## What
Two changes that together build the Player API side of the new notification pipeline:

**1. Scheduler split** (\`backend/data/pipeline/daily_update.py\`)
- Old: a single daily job at 3 AM ET running the full 4-step pipeline.
- New: two jobs.
  - \`external_fetch\` every 15 minutes — \`_step_injuries\` + \`_step_depth_charts\` (cheap external HTTP calls).
  - \`full_recalc\` daily at 3 AM ET — \`_step_baselines\` + \`_step_recalculate\` (heavy work across ~1300 players, unchanged cadence).
- \`run_daily_update()\` is preserved as the manual full-trigger entry point for \`POST /admin/update\` (no regression).

**2. Fake push endpoint** (\`backend/routers/admin.py\`)
- New: \`POST /admin/player-event\`, \`X-Admin-Key\` auth, body \`{ player_id, message, event_type?, player_name? }\`.
- Handler does NOT mutate any player table. It relays the payload to the Draft Kit Backend via webhook (\`BE_WEBHOOK_URL\` + \`X-Internal-Key\` from \`INTERNAL_WEBHOOK_KEY\` env).
- This is the explicit admin-side "force a notification" mechanism the rubric calls out.

## Why
- The notification rubric awards points for both an admin-controllable force-push (fake demo) and live propagation from real sources. The scheduler split makes external injury/depth data flow into the Player API within 15 minutes of a real change, while the new endpoint gives a one-curl demo path for graders that does not pollute production player data.
- McKenna confirmed in Discord that fake status pushes are sufficient for credit and that live pulling earns more — this PR delivers the source side of both.
- Heavy \`_step_recalculate\` stays daily because hitting it every 15 min would CPU-thrash and risk external rate limits.

## Verification
- [ ] After merge + deploy, observe api-server logs showing \`external_fetch\` firing on \`*:00 / *:15 / *:30 / *:45\` marks.
- [ ] \`full_recalc\` still runs at 3 AM ET (verify next morning logs).
- [ ] \`POST /admin/update\` regression: still kicks off the full 4-step pipeline.
- [ ] \`POST /admin/player-event\` returns 401 without \`X-Admin-Key\`, 503 if \`BE_WEBHOOK_URL\` not set, 200 once env is configured and be webhook is reachable.
- [ ] No mutation of \`batters_al\` / \`pitchers_al\` rows from \`POST /admin/player-event\` calls.

## Deploy notes
Once the Draft Kit Backend webhook is live, set these on api-server's \`/app/api/.env\`:
\`\`\`
BE_WEBHOOK_URL=https://<be-internal-host>/internal/notify
INTERNAL_WEBHOOK_KEY=<shared-secret-matching-be-env>
\`\`\`
Then \`cd /app/cl/api && sudo docker compose up -d --force-recreate api backend\`.

Closes #124