### PR TITLE
Add Logout Button to Authentication Page

### DIFF
--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -192,6 +192,17 @@ function Authentication() {
     setTimeout(() => setCopied(null), 2000);
   };
 
+  // ── handleLogout ──────────────────────────────────────────────────────────
+  // Clears all auth state and returns to the login screen.
+  // sessionStorage cleanup is handled automatically by the useEffect that
+  // watches user and token — setting both to null/"" triggers removeItem.
+
+  const handleLogout = () => {
+    setUser(null);
+    setToken("");
+    setApiKeys([]);
+  };
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
@@ -229,7 +240,15 @@ function Authentication() {
 
             {/* User info card */}
             <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-              <p className="text-xs font-bold text-white/40 uppercase mb-2">Signed in as</p>
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs font-bold text-white/40 uppercase">Signed in as</p>
+                <button
+                  onClick={handleLogout}
+                  className="rounded-lg bg-white/10 px-3 py-1 text-xs text-white/60 hover:bg-white/20 transition"
+                >
+                  Logout
+                </button>
+              </div>
               <p className="text-white font-bold">{user.name}</p>
               <p className="text-sm text-white/50">{user.email}</p>
             </div>


### PR DESCRIPTION
## What
- Added Logout button to the User info card (top-right, inline with "Signed in as" label)
- On click, clears user, token, and apiKeys state
- sessionStorage is cleared automatically via the existing useEffect that watches user and token
- After logout, the conditional render returns to the login screen

## Why
There was no way to log out after signing in other than closing the browser tab.
This is a basic account management requirement for any authenticated UI.

## Related Issue
#111 
