### PR TITLE
chore: tune fetch frequency, add reactive recalc, bump uvicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY api/ ./api/
 
 EXPOSE 8000
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/backend/data/pipeline/daily_update.py
+++ b/backend/data/pipeline/daily_update.py
@@ -343,7 +343,7 @@ def _full_recalc_cycle() -> None:
 def start_scheduler():
     """
     Start a background scheduler with two jobs:
-      - external_fetch: every 15 min (injuries + depth charts)
+      - external_fetch: every 30 min (injuries + depth charts)
       - full_recalc:    daily at 3 AM ET (baselines + player_value recalc)
     Returns the scheduler instance so the caller can shut it down on app exit.
     Called from backend/main.py lifespan event.
@@ -358,9 +358,9 @@ def start_scheduler():
     scheduler = BackgroundScheduler()
     scheduler.add_job(
         _external_fetch_cycle,
-        trigger=CronTrigger(minute="*/15"),
+        trigger=CronTrigger(minute="*/30"),
         id="external_fetch",
-        name="External fetch — injuries + depth (every 15 min)",
+        name="External fetch — injuries + depth (every 30 min)",
     )
     scheduler.add_job(
         _full_recalc_cycle,

--- a/backend/data/pipeline/recalc.py
+++ b/backend/data/pipeline/recalc.py
@@ -1,0 +1,195 @@
+"""
+Reactive recalc — injury / depth fetch가 감지한 변경 선수에 대해서만
+player_value를 즉시 재계산해서 DB에 반영하는 모듈.
+
+배경
+----
+- 평소엔 매일 3시 ET에 _step_recalculate가 전체 1300명 player_value 재계산함
+- 그러나 부상/뎁스가 낮에 변경되면 다음날 3시까지 bid가 옛 값으로 stale
+- Reactive recalc는 30분 fetch cycle에서 진짜 바뀐 선수만 즉시 다시 계산해
+  bid 정확도를 빠르게 복구함 (보통 사이클당 0~5명)
+
+호출 흐름
+--------
+  injury.fetch_and_update / depth_charts.fetch_and_update
+    → 변경된 player_id 추출
+    → recalculate_players([1234, 5678, ...])
+    → 각 선수: api 호출로 새 player_value 받아 DB UPDATE
+"""
+import logging
+import os
+from typing import List, Optional
+
+import requests
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# DB 연결 — daily_update.py / injury.py와 동일 패턴.
+# 자체 engine을 만들어 의존성 단순화 (다른 모듈 import 안 함).
+DATABASE_URL = "mysql+pymysql://root:{password}@{host}:3306/{db}".format(
+    password=os.getenv("MYSQL_ROOT_PASSWORD", ""),
+    host=os.getenv("MYSQL_HOST", "db"),
+    db=os.getenv("MYSQL_DATABASE", "ppa_dun_api"),
+)
+engine       = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+# api 서비스의 /player/value endpoint — Docker Compose 네트워크 내부 호출.
+API_VALUE_URL    = os.getenv("API_VALUE_URL", "http://api:8000/player/value")
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "")
+
+# 4개 player 테이블 메타. 선수 검색 + UPDATE 시 순회용.
+_TABLES = (
+    ("batters_al",  "batter"),
+    ("batters_nl",  "batter"),
+    ("pitchers_al", "pitcher"),
+    ("pitchers_nl", "pitcher"),
+)
+
+
+def _find_player(player_id: int) -> Optional[dict]:
+    """
+    주어진 player_id를 4개 테이블에서 검색해 row + table 정보 반환.
+    찾으면 dict에 'table', 'player_type' 추가해서 돌려줌.
+    어느 테이블에도 없으면 None.
+    """
+    db = SessionLocal()
+    try:
+        for table, ptype in _TABLES:
+            row = db.execute(
+                text(f"SELECT * FROM {table} WHERE player_id = :pid LIMIT 1"),
+                {"pid": player_id},
+            ).fetchone()
+            if row:
+                d = dict(row._mapping)
+                d["table"]       = table
+                d["player_type"] = ptype
+                return d
+    finally:
+        db.close()
+    return None
+
+
+def _call_player_value_api(player: dict) -> Optional[float]:
+    """
+    api 서비스의 /player/value endpoint로 POST → 새 player_value 반환.
+
+    daily_update.py의 _call_player_value와 동일한 payload 빌드 — 중복이긴
+    하지만 두 파일이 같은 API 계약을 따른다는 게 명확해서 의도적 중복.
+    실패 시 None (caller가 skip 처리).
+    """
+    position    = (player["position"] or "").upper()
+    player_type = player.get("player_type", "batter")
+
+    if player_type == "pitcher":
+        # IP / ERA가 없으면 의미 있는 계산 불가 — skip
+        if player["ip"] is None or player["era"] is None:
+            return None
+        stats_payload = {
+            "player_type":   "pitcher",
+            "IP":            player["ip"]   or 0.0,
+            "W":             player["w"]    or 0,
+            "SV":            player["sv"]   or 0,
+            "K":             player["so"]   or 0,
+            "ERA":           player["era"]  or 0.0,
+            "WHIP":          player["whip"] or 0.0,
+            "age":           player["current_age"],
+            "depth_order":   player["depth_order"],
+            "injury_status": player["injury_status"],
+        }
+    else:
+        # 타석 / 타율 없으면 skip
+        if player["ab"] is None or player["avg"] is None:
+            return None
+        stats_payload = {
+            "player_type":   "batter",
+            "AB":            player["ab"]   or 0,
+            "R":             player["r"]    or 0,
+            "HR":            player["hr"]   or 0,
+            "RBI":           player["rbi"]  or 0,
+            "SB":            player["sb"]   or 0,
+            "CS":            player["cs"]   or 0,
+            "AVG":           player["avg"]  or 0.0,
+            "age":           player["current_age"],
+            "depth_order":   player["depth_order"],
+            "injury_status": player["injury_status"],
+        }
+
+    payload = {
+        "player_name": str(player["player_id"]),
+        "position":    position,
+        "stats":       stats_payload,
+    }
+
+    try:
+        resp = requests.post(
+            API_VALUE_URL,
+            json=payload,
+            headers={"X-API-Key": INTERNAL_API_KEY},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return resp.json()["player_value"]
+    except Exception as e:
+        logger.warning(f"[reactive_recalc] /player/value failed pid={player['player_id']}: {e}")
+        return None
+
+
+def recalculate_players(player_ids: List[int]) -> int:
+    """
+    주어진 player_ids 각각에 대해 player_value 재계산 + DB UPDATE.
+
+    호출처: injury.fetch_and_update, depth_charts.fetch_and_update
+    호출 시점: 변경된 player_id 추출 직후
+
+    Returns: 성공적으로 update된 선수 수 (logging 및 모니터링용).
+
+    실패 케이스 (조용히 skip):
+      - 선수 ID가 어느 테이블에도 없음 (이상 데이터)
+      - api /player/value 호출 실패 (network, 5xx 등)
+      - 필수 스탯 누락으로 의미 있는 계산 불가
+      → 다음 사이클이나 daily full recalc에서 잡힘
+    """
+    if not player_ids:
+        return 0
+
+    success = 0
+    for pid in player_ids:
+        # 1) 선수 row + 어느 테이블인지 찾기
+        player = _find_player(pid)
+        if not player:
+            logger.warning(f"[reactive_recalc] player_id={pid} not found in any table")
+            continue
+
+        # 2) api 호출해서 새 player_value 받기
+        new_value = _call_player_value_api(player)
+        if new_value is None:
+            continue  # 위에서 이미 logging됨
+
+        # 3) DB UPDATE (선수가 속한 테이블에)
+        db = SessionLocal()
+        try:
+            db.execute(
+                text(
+                    f"UPDATE {player['table']} "
+                    f"SET player_value = :v WHERE player_id = :pid"
+                ),
+                {"v": new_value, "pid": pid},
+            )
+            db.commit()
+            success += 1
+        except Exception as e:
+            db.rollback()
+            logger.error(f"[reactive_recalc] UPDATE failed pid={pid}: {e}")
+        finally:
+            db.close()
+
+    logger.info(
+        f"[reactive_recalc] {success}/{len(player_ids)} player_value 갱신 완료"
+    )
+    return success

--- a/backend/data/sources/depth_charts.py
+++ b/backend/data/sources/depth_charts.py
@@ -163,6 +163,30 @@ def _update_players(rows: list[dict], league: str) -> tuple[int, int]:
     return matched, unmatched
 
 
+# ── Snapshot for reactive recalc ─────────────────────────────────────────────
+
+def _snapshot_depth_order() -> dict[int, int | None]:
+    """
+    4개 player 테이블에서 (player_id → depth_order) 매핑 한 번에 가져옴.
+
+    Reactive recalc용: fetch 전/후로 두 번 찍어서 비교하면
+    어떤 선수의 depth_order가 진짜로 바뀌었는지 알 수 있음.
+    None (= 뎁스 차트에 없음) 그대로 저장해서 None ↔ 숫자 변화도 잡힘.
+    """
+    db  = SessionLocal()
+    out = {}
+    try:
+        for table in ("batters_al", "batters_nl", "pitchers_al", "pitchers_nl"):
+            rows = db.execute(
+                text(f"SELECT player_id, depth_order FROM {table}")
+            ).fetchall()
+            for r in rows:
+                out[r._mapping["player_id"]] = r._mapping["depth_order"]
+    finally:
+        db.close()
+    return out
+
+
 # ── Public entry point ────────────────────────────────────────────────────────
 
 def _reset_depth_order() -> None:
@@ -190,7 +214,18 @@ def fetch_and_update() -> None:
     """
     Scrape ESPN depth charts for all 30 teams and update batter and pitcher tables.
     Called by daily_update.py.
+
+    Reactive recalc 통합 (2026-05):
+      fetch 전/후로 depth_order snapshot을 떠서 비교 →
+      진짜 바뀐 선수만 player_value 즉시 재계산.
+      → bid가 다음 3시 full recalc까지 stale하지 않고
+        30분 fetch cycle 내에 회복됨.
     """
+    # ── Reactive recalc 준비 ──
+    # reset 전에 옛 depth_order snapshot. 나중에 새 snapshot과 비교해
+    # 진짜 변경된 player_id만 추출 (보통 사이클당 0~5명).
+    old_depth_by_pid = _snapshot_depth_order()
+
     _reset_depth_order()
 
     try:
@@ -235,6 +270,20 @@ def fetch_and_update() -> None:
         f"| total_unmatched={total_unmatched} "
         f"| failed_teams={failed_teams}"
     )
+
+    # ── Reactive recalc 실행 ──
+    # 새 snapshot 뜨고 old vs new 비교 → depth 바뀐 player_id만 player_value 재계산.
+    # 라인업 변경 (예: 1군 → 2군)이 즉시 bid에 반영됨.
+    new_depth_by_pid = _snapshot_depth_order()
+    changed_ids = [
+        pid for pid, new_d in new_depth_by_pid.items()
+        if old_depth_by_pid.get(pid) != new_d
+    ]
+    if changed_ids:
+        # lazy import — 모듈 로딩 시점 순환 의존 회피
+        from data.pipeline.recalc import recalculate_players
+        logger.info(f"[depth] {len(changed_ids)} player(s) depth changed — triggering reactive recalc")
+        recalculate_players(changed_ids)
 
 
 if __name__ == "__main__":

--- a/backend/data/sources/injury.py
+++ b/backend/data/sources/injury.py
@@ -138,6 +138,30 @@ def _fetch_from_html() -> list[dict]:
     return rows
 
 
+# ── Snapshot for reactive recalc ─────────────────────────────────────────────
+
+def _snapshot_injury_status() -> dict[int, str | None]:
+    """
+    4개 player 테이블에서 (player_id → injury_status) 매핑 한 번에 가져옴.
+
+    Reactive recalc용: fetch 전/후로 두 번 찍어서 비교하면
+    어떤 선수의 injury_status가 진짜로 바뀌었는지 알 수 있음.
+    None (= 부상자 명단에 없음 = 정상) 그대로 저장해서 None ↔ "IL-15" 변화도 잡힘.
+    """
+    db  = SessionLocal()
+    out = {}
+    try:
+        for table in ("batters_al", "batters_nl", "pitchers_al", "pitchers_nl"):
+            rows = db.execute(
+                text(f"SELECT player_id, injury_status FROM {table}")
+            ).fetchall()
+            for r in rows:
+                out[r._mapping["player_id"]] = r._mapping["injury_status"]
+    finally:
+        db.close()
+    return out
+
+
 # ── Update ────────────────────────────────────────────────────────────────────
 
 def _reset_injury_status() -> None:
@@ -209,6 +233,12 @@ def fetch_and_update() -> None:
     """
     Fetch injury data (API-first, HTML fallback) and update batter and pitcher tables.
     Called by daily_update.py as Step 1 of the daily pipeline.
+
+    Reactive recalc 통합 (2026-05):
+      fetch 전/후로 injury_status snapshot을 떠서 비교 →
+      진짜 바뀐 선수만 player_value 즉시 재계산.
+      → bid 정확도가 다음 3시 full recalc까지 stale하지 않고
+        30분 fetch cycle 내에 회복됨.
     """
     # 1st attempt: JSON API
     try:
@@ -229,6 +259,11 @@ def fetch_and_update() -> None:
         logger.error("[injury] No data retrieved — skipping update")
         return
 
+    # ── Reactive recalc 준비 ──
+    # update 전에 옛 injury_status snapshot. 나중에 새 snapshot과 비교해
+    # 진짜 변경된 player_id만 추출.
+    old_status_by_pid = _snapshot_injury_status()
+
     # Clear yesterday's injury data before writing today's
     _reset_injury_status()
 
@@ -237,6 +272,20 @@ def fetch_and_update() -> None:
         f"[injury] source={source} | fetched={len(rows)} "
         f"| matched={matched} | unmatched={unmatched}"
     )
+
+    # ── Reactive recalc 실행 ──
+    # 새 snapshot 뜨고 old vs new 비교 → 바뀐 player_id만 player_value 재계산.
+    # 보통 사이클당 0~5명. recalculate_players는 실패해도 throw 안 함 (안전).
+    new_status_by_pid = _snapshot_injury_status()
+    changed_ids = [
+        pid for pid, new_st in new_status_by_pid.items()
+        if old_status_by_pid.get(pid) != new_st
+    ]
+    if changed_ids:
+        # lazy import — 모듈 로딩 시점 순환 의존 회피
+        from data.pipeline.recalc import recalculate_players
+        logger.info(f"[injury] {len(changed_ids)} player(s) injury changed — triggering reactive recalc")
+        recalculate_players(changed_ids)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
- External fetch cycle: 15 min → 30 min (\`backend/data/pipeline/daily_update.py\`)
- api Dockerfile uvicorn: 1 worker → 2 workers (halves Draft Room values endpoint latency)
- New \`backend/data/pipeline/recalc.py\` with \`recalculate_players(player_ids)\` helper
- \`backend/data/sources/injury.py\`: snapshot injury_status before / after update, call \`recalculate_players\` for changed player_ids
- \`backend/data/sources/depth_charts.py\`: same pattern for depth_order

## Why
- 15-min ESPN polling was over-polling vs the actual injury / depth publish cadence — 30 min still catches changes within ~15 min average
- Bumping api workers from 1 to 2 fixes the ~20 s Draft Room load by enabling true concurrency for the 1300 per-player /player/bid/id calls. backend service stays at 1 worker (apscheduler safety)
- Reactive recalc closes the gap where injury / depth changes weren't reflected in player_value / bid until next 3 AM full recalc. Cost is tiny (~5 players per cycle vs 1300/day for the daily recalc)

## Verification
- [ ] Scheduler logs show external_fetch firing on :00 / :30 marks
- [ ] After admin force-changes an injury, reactive recalc log line appears in that cycle
- [ ] Draft Room values request latency drops noticeably

Closes #128