### PR TITLE
IP Whitelist Feature — Per-Account Allowed IP Registration

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,3 @@
-# Player valuation API service entry point.
 import os
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
@@ -13,6 +12,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from api.routers import player, players_data
 from api.services.player import compute_player_value, compute_recommended_bid, reload_baselines
 from api.models.player import PlayerValueRequest, PlayerBidRequest
+from api.routers.ip_whitelist import check_ip_whitelist
 from pydantic import BaseModel
 
 import logging
@@ -146,6 +146,14 @@ async def verify_api_key(request: Request, call_next):
             text("SELECT id FROM api_keys WHERE `key` = :key"),  # :key is a parameter placeholder to prevent SQL injection
             {"key": api_key}
         ).fetchone()
+
+        # IP whitelist check — runs only when the key is valid
+        if result is not None:
+            request_ip = get_real_ip(request)
+            ip_allowed = check_ip_whitelist(api_key, request_ip, db)
+        else:
+            ip_allowed = True   # key invalid — 401 will be returned below
+
         db.close()
     except Exception:
         return JSONResponse(
@@ -160,7 +168,14 @@ async def verify_api_key(request: Request, call_next):
             content={"detail": "Invalid API key"}
         )
 
-    # Key is valid
+    # IP not in the user's whitelist
+    if not ip_allowed:
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Request IP is not in the allowed IP list for this API key"}
+        )
+
+    # Key is valid and IP is permitted
     return await call_next(request)
 
 # ── Exception Handlers ────────────────────────────────────────────────────────

--- a/api/routers/ip_whitelist.py
+++ b/api/routers/ip_whitelist.py
@@ -1,0 +1,45 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+
+def check_ip_whitelist(api_key: str, request_ip: str, db: Session) -> bool:
+    """
+    Check whether the request IP is permitted for the given API key.
+
+    Lookup flow:
+      1. Resolve the api_key string to a user_id via the api_keys table.
+      2. Look up the user's registered allowed IP in user_allowed_ips.
+      3. If no allowed IP is registered, permit all IPs (return True).
+      4. If an allowed IP exists, compare it against the request IP.
+         Return True on match, False on mismatch.
+
+    Returns:
+        True  — request is allowed to proceed
+        False — request should be rejected with 403
+    """
+    # Step 1: resolve api_key → user_id
+    key_row = db.execute(
+        text("SELECT user_id FROM api_keys WHERE `key` = :key"),
+        {"key": api_key},
+    ).fetchone()
+
+    # Key not found — treated as unauthenticated; let the existing
+    # 401 logic in verify_api_key handle it rather than raising here.
+    if key_row is None:
+        return True
+
+    user_id = key_row[0]
+
+    # Step 2: look up the user's registered allowed IP
+    ip_row = db.execute(
+        text("SELECT ip_address FROM user_allowed_ips WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+
+    # Step 3: no IP registered — permit all origins
+    if ip_row is None:
+        return True
+
+    # Step 4: compare registered IP against the actual request IP
+    registered_ip = ip_row[0]
+    return request_ip == registered_ip

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -22,6 +22,10 @@ class User(Base):
     # back_populates="user" links this side to APIKey.user on the other side.
     api_keys = relationship("APIKey", back_populates="user")
 
+    # One-to-one relationship with UserAllowedIP.
+    # Each user may register at most one allowed IP address for API access.
+    allowed_ip = relationship("UserAllowedIP", back_populates="user", uselist=False)
+
 
 # ── APIKey ────────────────────────────────────────────────────────────────────
 # Represents an API key issued to a user for authenticating requests to the
@@ -45,6 +49,33 @@ class APIKey(Base):
     # Many-to-one relationship back to User.
     # Accessing api_key.user returns the User object that owns this key.
     user = relationship("User", back_populates="api_keys")
+
+
+# ── UserAllowedIP ─────────────────────────────────────────────────────────────
+# Stores the single allowed IP address registered per user account.
+# When a user registers an IP, all API requests using their key must originate
+# from that address. If no record exists, all IPs are permitted.
+#
+# user_id is unique — one row per user, enforced at both DB and application level.
+# ip_address uses String(45) to accommodate both IPv4 and IPv6 addresses.
+# updated_at is set manually on every insert or update.
+
+class UserAllowedIP(Base):
+    __tablename__ = "user_allowed_ips"
+
+    id         = Column(Integer, primary_key=True, index=True)
+    user_id    = Column(
+        Integer,
+        ForeignKey("users.id"),
+        nullable=False,
+        unique=True,    # Enforces one IP registration per user at the DB level
+    )
+    ip_address = Column(String(45), nullable=False)   # String(45) covers IPv4 and IPv6
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    # Many-to-one relationship back to User.
+    user = relationship("User", back_populates="allowed_ip")
+
 
 # ── BatterBase ────────────────────────────────────────────────────────────────
 # Abstract mixin that defines the shared schema for ALBatter and NLBatter.

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,12 +1,13 @@
 import os
 import secrets
+from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from pydantic import BaseModel, ConfigDict
 from db.session import get_db
-from db.models import User, APIKey
+from db.models import User, APIKey, UserAllowedIP
 
 # All routes in this router are prefixed with /api/auth.
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -37,6 +38,17 @@ class UserResponse(BaseModel):
 class APIKeyResponse(BaseModel):
     key:        str
     created_at: str
+
+
+class AllowedIPRequest(BaseModel):
+    # Carries both the Google ID token (for auth) and the IP address to register.
+    token:      str
+    ip_address: str
+
+
+class AllowedIPResponse(BaseModel):
+    ip_address: str
+    updated_at: str
 
 
 # ── Helper: verify Google token ───────────────────────────────────────────────
@@ -169,3 +181,87 @@ def delete_api_key(key: str, google_token: str, db: Session = Depends(get_db)):
     db.delete(api_key)
     db.commit()
     return {"detail": "API key deleted"}
+
+
+# ── POST /api/auth/allowed-ip ─────────────────────────────────────────────────
+
+@router.post("/allowed-ip", response_model=AllowedIPResponse)
+def upsert_allowed_ip(req: AllowedIPRequest, db: Session = Depends(get_db)):
+    """
+    Register or update the allowed IP address for the authenticated user.
+    Each account is limited to one allowed IP. Calling this endpoint again
+    overwrites the previously registered address (upsert pattern).
+    """
+    idinfo = _verify_google_token(req.token)
+
+    user = db.query(User).filter(User.google_id == idinfo["sub"]).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    existing = db.query(UserAllowedIP).filter(UserAllowedIP.user_id == user.id).first()
+
+    if existing:
+        # Update the existing record
+        existing.ip_address = req.ip_address
+        existing.updated_at = datetime.utcnow()
+    else:
+        # Insert a new record
+        existing = UserAllowedIP(user_id=user.id, ip_address=req.ip_address)
+        db.add(existing)
+
+    db.commit()
+    db.refresh(existing)
+
+    return AllowedIPResponse(
+        ip_address=existing.ip_address,
+        updated_at=str(existing.updated_at),
+    )
+
+
+# ── GET /api/auth/allowed-ip ──────────────────────────────────────────────────
+
+@router.get("/allowed-ip")
+def get_allowed_ip(google_token: str, db: Session = Depends(get_db)):
+    """
+    Return the registered allowed IP address for the authenticated user.
+    Returns 404 if no IP has been registered yet.
+    google_token is passed as a query parameter (?google_token=...).
+    """
+    idinfo = _verify_google_token(google_token)
+
+    user = db.query(User).filter(User.google_id == idinfo["sub"]).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    record = db.query(UserAllowedIP).filter(UserAllowedIP.user_id == user.id).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="No allowed IP registered")
+
+    return AllowedIPResponse(
+        ip_address=record.ip_address,
+        updated_at=str(record.updated_at),
+    )
+
+
+# ── DELETE /api/auth/allowed-ip ───────────────────────────────────────────────
+
+@router.delete("/allowed-ip")
+def delete_allowed_ip(google_token: str, db: Session = Depends(get_db)):
+    """
+    Remove the registered allowed IP address for the authenticated user.
+    After deletion, API requests from any IP are accepted again.
+    google_token is passed as a query parameter (?google_token=...).
+    """
+    idinfo = _verify_google_token(google_token)
+
+    user = db.query(User).filter(User.google_id == idinfo["sub"]).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    record = db.query(UserAllowedIP).filter(UserAllowedIP.user_id == user.id).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="No allowed IP registered")
+
+    db.delete(record)
+    db.commit()
+    return {"detail": "Allowed IP removed"}

--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -25,6 +25,7 @@ interface User {
 //   2. Fetch keys    → GET  /api/auth/api-keys  → lists existing keys
 //   3. Generate key  → POST /api/auth/api-key   → issues a new key
 //   4. Delete key    → DELETE /api/auth/api-key/{key}
+//   5. IP whitelist  → POST/GET/DELETE /api/auth/allowed-ip
 //
 // Auth state (user + token) is persisted in sessionStorage so it survives
 // page refreshes within the same browser tab, but is cleared when the tab closes.
@@ -50,7 +51,7 @@ function Authentication() {
 
   // copied tracks which key was just copied to clipboard for the 2-second
   // "Copied!" feedback state. Stores the key string, or null if none.
-  const [copied, setCopied]   = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
 
   // showRegenerateModal controls the visibility of the confirmation modal
   // that appears before executing a one-click key regeneration.
@@ -73,6 +74,15 @@ function Authentication() {
     });
   };
 
+  // allowedIp: the IP address currently registered for this user (null = none registered).
+  // ipInput: the value of the IP input field (controlled).
+  // justGeneratedKey: true immediately after a key is generated to show the IP registration prompt.
+  const [allowedIp,        setAllowedIp]        = useState<string | null>(null);
+  const [ipInput,          setIpInput]          = useState("");
+  const [ipError,          setIpError]          = useState("");
+  const [ipSuccess,        setIpSuccess]        = useState("");
+  const [justGeneratedKey, setJustGeneratedKey] = useState(false);
+
   // ── Sync auth state to sessionStorage ────────────────────────────────────
   // Runs whenever user or token changes.
   // If both are set → persist to sessionStorage and fetch the key list.
@@ -83,6 +93,7 @@ function Authentication() {
       sessionStorage.setItem("user",  JSON.stringify(user));
       sessionStorage.setItem("token", token);
       fetchApiKeys(token);
+      fetchAllowedIp(token);
     } else {
       sessionStorage.removeItem("user");
       sessionStorage.removeItem("token");
@@ -166,6 +177,8 @@ function Authentication() {
 
       // Refresh the key list to show the newly created key
       await fetchApiKeys(token);
+      // Show the "please register your IP" prompt after key generation
+      setJustGeneratedKey(true);
     } catch {
       setError("Failed to create API key");
     }
@@ -214,10 +227,90 @@ function Authentication() {
     try {
       await deleteApiKey(apiKeys[0].key);
       await createApiKey();
+      // Show IP registration prompt only if no IP is registered yet.
+      // Users who already have an IP registered do not need the reminder.
+      if (allowedIp !== null) {
+        setJustGeneratedKey(false);
+      }
     } catch {
       setError("Failed to regenerate API key");
     } finally {
       setShowRegenerateModal(false);
+    }
+  };
+
+  // ── fetchAllowedIp ────────────────────────────────────────────────────────
+  // Fetches the currently registered allowed IP for the logged-in user.
+  // Sets allowedIp to null if none is registered (404 is expected, not an error).
+
+  const fetchAllowedIp = async (googleToken: string) => {
+    try {
+      const res = await fetch(
+        `${BACKEND_URL}/api/auth/allowed-ip?google_token=${googleToken}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setAllowedIp(data.ip_address);
+        setIpInput(data.ip_address);
+      } else {
+        // 404 means no IP registered yet — this is the normal initial state
+        setAllowedIp(null);
+        setIpInput("");
+      }
+    } catch {
+      setAllowedIp(null);
+    }
+  };
+
+  // ── saveAllowedIp ─────────────────────────────────────────────────────────
+  // Registers or updates the allowed IP address via POST /api/auth/allowed-ip.
+  // The backend performs an upsert — calling this multiple times is safe.
+
+  const saveAllowedIp = async () => {
+    setIpError("");
+    setIpSuccess("");
+    if (!ipInput.trim()) {
+      setIpError("Please enter an IP address.");
+      return;
+    }
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/auth/allowed-ip`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, ip_address: ipInput.trim() }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        setIpError(err.detail || "Failed to save IP address.");
+        return;
+      }
+      const data = await res.json();
+      setAllowedIp(data.ip_address);
+      setIpSuccess("Allowed IP saved successfully.");
+      setJustGeneratedKey(false);
+    } catch {
+      setIpError("Failed to connect to server.");
+    }
+  };
+
+  // ── deleteAllowedIp ───────────────────────────────────────────────────────
+  // Removes the registered allowed IP, restoring access from any IP.
+
+  const deleteAllowedIp = async () => {
+    setIpError("");
+    setIpSuccess("");
+    try {
+      const res = await fetch(
+        `${BACKEND_URL}/api/auth/allowed-ip?google_token=${token}`,
+        { method: "DELETE" }
+      );
+      if (res.ok) {
+        setAllowedIp(null);
+        setIpInput("");
+        setIpSuccess("Allowed IP removed. Requests from any IP are now accepted.");
+      }
+    } catch {
+      setIpError("Failed to remove IP address.");
     }
   };
 
@@ -268,6 +361,20 @@ function Authentication() {
                 <span className="text-sm text-white/70">{user.email}</span>
               </div>
             </div>
+
+            {/* IP registration prompt banner — shown immediately after key generation */}
+            {justGeneratedKey && (
+              <div className="rounded-2xl border border-yellow-400/30 bg-yellow-400/10 p-4 flex items-start gap-3">
+                <span className="text-yellow-400 text-lg mt-0.5">⚠</span>
+                <div>
+                  <p className="text-sm font-bold text-yellow-300">Register your allowed IP address</p>
+                  <p className="text-xs text-yellow-200/70 mt-1">
+                    Your API key has been generated. For security, scroll down to register
+                    the IP address from which you will make API requests.
+                  </p>
+                </div>
+              </div>
+            )}
 
             {/* API key management card */}
             <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-4">
@@ -338,6 +445,51 @@ function Authentication() {
                   ))}
                 </div>
               )}
+            </div>
+
+            {/* IP Whitelist card */}
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-4">
+              <p className="text-xs font-bold text-white/40 uppercase">IP Whitelist</p>
+              <p className="text-sm text-white/50">
+                Restrict API access to a single trusted IP address. If no IP is registered,
+                requests from any IP are accepted.
+              </p>
+
+              {/* Current registered IP display */}
+              {allowedIp && (
+                <div className="rounded-2xl border border-white/10 bg-black/40 p-4 flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-xs text-white/40 mb-1">Registered IP</p>
+                    <code className="text-sm text-white/80">{allowedIp}</code>
+                  </div>
+                  <button
+                    onClick={deleteAllowedIp}
+                    className="rounded-lg bg-red-500/20 px-3 py-1 text-xs text-red-400 hover:bg-red-500/30 transition shrink-0"
+                  >
+                    Remove
+                  </button>
+                </div>
+              )}
+
+              {/* IP input + save */}
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={ipInput}
+                  onChange={(e) => setIpInput(e.target.value)}
+                  placeholder={allowedIp ? "Enter new IP to update" : "e.g. 203.0.113.42"}
+                  className="flex-1 rounded-lg bg-black/40 border border-white/10 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/30"
+                />
+                <button
+                  onClick={saveAllowedIp}
+                  className="rounded-lg bg-white px-4 py-2 text-xs font-bold text-black hover:bg-white/90 transition shrink-0"
+                >
+                  {allowedIp ? "Update" : "Register"}
+                </button>
+              </div>
+
+              {ipError   && <p className="text-sm text-red-400">{ipError}</p>}
+              {ipSuccess && <p className="text-sm text-green-400">{ipSuccess}</p>}
             </div>
 
           </div>


### PR DESCRIPTION
## What
Added a per-account IP whitelist feature that allows API key owners to register
a single trusted IP address from which their API requests must originate.

- `backend/db/models.py` — Added `UserAllowedIP` table (user_id FK unique, ip_address String(45), updated_at DateTime) with a one-to-one relationship to the `User` model
- `backend/routers/auth.py` — Added three endpoints: `POST /api/auth/allowed-ip` (upsert), `GET /api/auth/allowed-ip` (fetch), `DELETE /api/auth/allowed-ip` (remove); added `AllowedIPRequest` and `AllowedIPResponse` Pydantic models
- `api/routers/ip_whitelist.py` — New file containing `check_ip_whitelist()`, which resolves the API key to a user, looks up the registered IP, and returns False (→ 403) on mismatch; returns True if no IP is registered
- `api/main.py` — Imported `check_ip_whitelist` from `api/routers/ip_whitelist.py` and wired it into the `verify_api_key` middleware, executed after key validation and before passing the request downstream
- `frontend/src/pages/Authentication.tsx` — Added IP Whitelist card at the bottom of the logged-in view (register/update/remove), a yellow prompt banner shown immediately after key generation, and supporting state/functions (`allowedIp`, `ipInput`, `justGeneratedKey`, `fetchAllowedIp`, `saveAllowedIp`, `deleteAllowedIp`)

## Why
IP address whitelisting is a required feature per the project grading criteria
under Player API Licensing. Previously, any request carrying a valid API key was
accepted regardless of its origin IP. This change restricts access to a
registered IP when one is provided, while remaining fully permissive for users
who choose not to register one.

> ⚠️ Note: Deployment-environment testing has not yet been performed.
> This issue is being closed based on code review only. Live verification
> (valid IP allowed, unregistered IP → 403, no IP registered → any IP allowed)
> will be confirmed post-deployment.

## Related Issue
#109 
