### PR TITLE
feat: log authenticated API requests for per-user usage tracking

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,8 @@
 # Player valuation API service entry point.
 
 import os
+import time
+from datetime import datetime
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -145,7 +147,7 @@ async def verify_api_key(request: Request, call_next):
     try:
         db = SessionLocal()
         result = db.execute(
-            text("SELECT id FROM api_keys WHERE `key` = :key"),  # :key is a parameter placeholder to prevent SQL injection
+            text("SELECT id, user_id FROM api_keys WHERE `key` = :key"),  # :key is a parameter placeholder to prevent SQL injection
             {"key": api_key}
         ).fetchone()
 
@@ -177,8 +179,38 @@ async def verify_api_key(request: Request, call_next):
             content={"detail": "Request IP is not in the allowed IP list for this API key"}
         )
 
-    # Key is valid and IP is permitted
-    return await call_next(request)
+    # Key is valid and IP is permitted — time the request and log it for the
+    # per-user usage dashboard (Grafana reads api_request_logs via MySQL).
+    user_id = result[1]
+    start = time.time()
+    response = await call_next(request)
+    duration_ms = (time.time() - start) * 1000.0
+
+    try:
+        log_db = SessionLocal()
+        log_db.execute(
+            text("""
+                INSERT INTO api_request_logs
+                    (api_key, user_id, path, status, duration_ms, ts)
+                VALUES
+                    (:key, :uid, :path, :status, :dur, :ts)
+            """),
+            {
+                "key": api_key,
+                "uid": user_id,
+                "path": request.url.path,
+                "status": response.status_code,
+                "dur": duration_ms,
+                "ts": datetime.utcnow(),
+            },
+        )
+        log_db.commit()
+        log_db.close()
+    except Exception as exc:
+        # Logging failure must not break the response. Just record and move on.
+        logging.warning("api_request_logs insert failed: %s", exc)
+
+    return response
 
 # ── Exception Handlers ────────────────────────────────────────────────────────
 # Simple handler to return a cleaner error message instead of default FastAPI 422 error response

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -304,3 +304,21 @@ class LeagueBaseline(Base):
     mean        = Column(Float,       nullable=False)
     std         = Column(Float,       nullable=False)
     computed_at = Column(DateTime,    nullable=False)
+
+
+# ── APIRequestLog ─────────────────────────────────────────────────────────────
+# Logs each authenticated API request for per-user usage tracking.
+# Inserted by api/main.py middleware after each request from a user-issued key.
+# Queried by Grafana (per-user dashboard) via MySQL data source.
+# INTERNAL_API_KEY traffic is excluded (no logging).
+
+class APIRequestLog(Base):
+    __tablename__ = "api_request_logs"
+
+    id          = Column(Integer, primary_key=True, index=True)
+    api_key     = Column(String(64),  nullable=False)              # which key issued the call (audit)
+    user_id     = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    path        = Column(String(255), nullable=True)               # e.g. /player/bid
+    status      = Column(Integer,     nullable=True)               # HTTP response code
+    duration_ms = Column(Float,       nullable=True)               # request processing time
+    ts          = Column(DateTime,    nullable=False, default=datetime.utcnow, index=True)


### PR DESCRIPTION
## What
- New \`APIRequestLog\` ORM model in \`backend/db/models.py\`; \`Base.metadata.create_all\` provisions the \`api_request_logs\` table automatically on the next backend deploy. Columns: \`api_key\`, \`user_id\`, \`path\`, \`status\`, \`duration_ms\`, \`ts\` plus indexes on \`user_id, ts\` for the dashboard query.
- \`api/main.py\` auth middleware now selects \`(id, user_id)\` from \`api_keys\` instead of just \`id\`, and after a successful auth + IP check, times the downstream call and inserts one row into \`api_request_logs\` using a fresh \`SessionLocal\`. Failure to log is caught and warned — the response is returned regardless.
- INTERNAL_API_KEY traffic (be → api machine path) hits the early-return branch before the logging code, so internal calls are intentionally not recorded. Same for the exempt paths (\`/health\`, \`/demo\`, \`/internal\`, \`/docs\`, OPTIONS).
- Added \`import time\` and \`from datetime import datetime\` to support timing and the timestamp column.

## Why
- Enables a per-user usage dashboard in Grafana (running on the monitoring VM, now reachable to the api-server's MySQL via the new VPC peering + firewall rule). Grafana will read \`api_request_logs\` directly via the MySQL data source.
- Defining the table as a SQLAlchemy model rather than raw SQL keeps it consistent with the existing User / APIKey / UserAllowedIP / Batter / Pitcher / LeagueBaseline models, so no manual SQL is needed for fresh environments and the schema is version-controlled.
- The logging is intentionally swallowed-on-failure so introducing it can never take down the API. If the table doesn't exist yet (e.g. api gets deployed before backend), each request still succeeds and the only effect is a warn log per request until backend deploy creates the table.
- Selecting user_id in the same query that already runs for auth avoids an extra round-trip — middleware overhead remains a single SELECT plus one INSERT per logged request.

## Verification
- [ ] After merge + deploy, hit any authenticated endpoint and confirm \`SELECT COUNT(*) FROM api_request_logs\` increases.
- [ ] Confirm INTERNAL_API_KEY traffic (be → api) does NOT show up in the table.
- [ ] Confirm \`/health\`, \`/demo/*\`, \`/internal/*\`, \`/docs\` do NOT produce log rows.
- [ ] Verify request handler still returns the same response payload (no regression).

Closes #134