### PR TITLE
feat: embed Grafana usage dashboard iframe in Authentication page

### DIFF
--- a/frontend/src/pages/Authentication.tsx
+++ b/frontend/src/pages/Authentication.tsx
@@ -519,6 +519,23 @@ function Authentication() {
               {ipSuccess && <p className="text-sm text-green-400">{ipSuccess}</p>}
             </div>
 
+            {/* ── API Usage dashboard ────────────────────────────────────────── */}
+            {/* Grafana panel embedded as an iframe. The dashboard's $user_id    */}
+            {/* template variable is pinned to the signed-in user, so the        */}
+            {/* signed-in user only sees their own request counts / latency.     */}
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 space-y-4">
+              <p className="text-xs font-bold text-white/40 uppercase">Your API Usage</p>
+              <iframe
+                src={`https://grafana.ppa-dun.site/d/user-api-usage/user-api-usage?orgId=1&kiosk=tv&theme=dark&var-user_id=${user.id}&refresh=30s`}
+                className="w-full rounded-xl"
+                style={{ height: '720px', border: 'none' }}
+                title="API Usage Dashboard"
+              />
+              <p className="text-xs text-white/40">
+                Last 24 hours. Powered by Grafana.
+              </p>
+            </div>
+
           </div>
         )}
       </div>


### PR DESCRIPTION
## What
- Added an iframe to the signed-in section of \`frontend/src/pages/Authentication.tsx\` rendering the Grafana \`user-api-usage\` dashboard.
- Iframe URL pins \`var-user_id=\${user.id}\` so each signed-in account only sees their own request counts / latency.
- Used \`kiosk=tv\` to hide Grafana chrome, \`theme=dark\` to match the site, and \`refresh=30s\` for a live feel.
- Placed as a new card right after the existing IP whitelist card, inside the \`{user && (...)}\` block — so unauthenticated visitors do not see it.

## Why
- Backend logging landed in #134 — every authenticated request now writes to \`api_request_logs\`. The data sits in MySQL with no user-facing surface until this iframe is added.
- All the surrounding infra is already in place out-of-repo: DNS \`grafana.ppa-dun.site\`, Caddy + Let's Encrypt for HTTPS on the monitoring VM, MySQL data source pointing to \`10.30.0.2\` over the new VPC peering + firewall rule, anonymous viewer + iframe-embedding allowed on Grafana.
- Iframe (rather than rebuilding the chart in React) was the explicit trade-off: the dashboard stays editable inside Grafana's UI, we get time range / refresh / panel zoom for free, and the chart implementation stays out of the marketing-site bundle.

## Verification
- [ ] After merge + deploy, sign in to \`api.ppa-dun.site\` and confirm the iframe renders below the API Keys / Allowed IP cards.
- [ ] Confirm the data shown matches a direct query: \`SELECT COUNT(*) FROM api_request_logs WHERE user_id = <my id>\`.
- [ ] Sign in as a different account and confirm the dashboard scopes to that user (no other user's data is visible).

Closes #136