### PR TITLE
feat: 30-min MLB news RSS poll → notification webhook push

### DIFF
--- a/backend/data/pipeline/daily_update.py
+++ b/backend/data/pipeline/daily_update.py
@@ -324,6 +324,62 @@ def _external_fetch_cycle() -> None:
     logger.info("=== External fetch cycle finished ===")
 
 
+def _news_fetch_cycle() -> None:
+    """RSS news poll — every 30 min, pull the Yahoo MLB feed and push one
+    notification per newly-seen story to the BE webhook. Bootstrap cycles
+    (empty ledger) record items but do not notify, so a freshly-deployed
+    scheduler does not toast-flood every connected browser with a 20-item
+    backlog.
+
+    Each item is sent through the same `/internal/notify` webhook that
+    injury/depth alerts use. `event_type="NEWS"` lets the FE pick the right
+    prefix/variant; `player_id="MLB_NEWS"` is a placeholder because the BE
+    notification schema requires a non-null player_id (the FE ignores the
+    value for NEWS events).
+    """
+    from data.sources.mlb_news import find_new_items
+
+    logger.info("=== News fetch cycle started ===")
+
+    be_webhook_url = os.getenv("BE_WEBHOOK_URL")
+    internal_key = os.getenv("INTERNAL_WEBHOOK_KEY")
+    if not be_webhook_url or not internal_key:
+        logger.warning("[news_fetch] BE_WEBHOOK_URL or INTERNAL_WEBHOOK_KEY not set — skipping")
+        return
+
+    try:
+        new_items = find_new_items()
+    except Exception as e:
+        logger.error(f"[news_fetch] find_new_items failed: {e}")
+        return
+
+    if not new_items:
+        logger.info("=== News fetch cycle finished (no new items) ===")
+        return
+
+    notified = 0
+    for item in new_items:
+        payload = {
+            "player_id": "MLB_NEWS",
+            "message": item.title,
+            "event_type": "NEWS",
+            "player_name": None,
+        }
+        try:
+            resp = requests.post(
+                be_webhook_url,
+                json=payload,
+                headers={"X-Internal-Key": internal_key},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            notified += 1
+        except requests.RequestException as e:
+            logger.warning(f"[news_fetch] webhook failed for guid={item.guid}: {e}")
+
+    logger.info(f"=== News fetch cycle finished — notified {notified}/{len(new_items)} items ===")
+
+
 def _full_recalc_cycle() -> None:
     """Heavy recalc loop that runs once daily at 3 AM ET — baselines +
     player_value across all ~1300 players. Kept on the original daily cadence
@@ -362,6 +418,14 @@ def start_scheduler():
         id="external_fetch",
         name="External fetch — injuries + depth (every 30 min)",
     )
+    # News poller offset by 5 min so it doesn't fire at the same instant
+    # as the injury/depth fetch (avoids stacked CPU + outbound HTTP bursts).
+    scheduler.add_job(
+        _news_fetch_cycle,
+        trigger=CronTrigger(minute="5,35"),
+        id="news_fetch",
+        name="News fetch — MLB RSS → notifications (every 30 min)",
+    )
     scheduler.add_job(
         _full_recalc_cycle,
         trigger=CronTrigger(hour=3, minute=0, timezone="America/New_York"),
@@ -369,7 +433,10 @@ def start_scheduler():
         name="Full recalc — baselines + player_value (3AM ET daily)",
     )
     scheduler.start()
-    logger.info("Scheduler started — external_fetch every 15 min, full_recalc at 3AM ET")
+    logger.info(
+        "Scheduler started — external_fetch every 30 min, news_fetch every 30 min, "
+        "full_recalc at 3AM ET"
+    )
     return scheduler
 
 

--- a/backend/data/sources/mlb_news.py
+++ b/backend/data/sources/mlb_news.py
@@ -1,0 +1,160 @@
+"""MLB news RSS poller — feeds the Draft Kit notification system.
+
+Every poll cycle:
+  1. Fetch the Yahoo Sports MLB RSS feed.
+  2. Parse out (guid, title, link) for each <item>.
+  3. Compare against the `mlb_news_seen` ledger; anything not in the ledger
+     is a new story.
+  4. Record new guids in the ledger and return them so the caller can push
+     a notification per item.
+  5. On the very first call (ledger empty) we still record everything but
+     return no items — this prevents a backlog-flood of toasts when the
+     scheduler is freshly deployed.
+
+Old ledger rows are pruned to a bounded count so the table does not grow
+forever; the cap is generous enough that no Yahoo MLB story should be
+re-notified once it has been seen.
+
+We parse the RSS with stdlib (xml.etree) rather than pulling in feedparser
+because we only need three fields and the feed is well-formed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import List, Optional
+
+import requests
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.models import MLBNewsSeen
+
+logger = logging.getLogger(__name__)
+
+# Yahoo Sports MLB feed — same source the homepage already polls via rss2json,
+# but here we hit it directly server-side and parse the XML ourselves.
+RSS_URL = "https://sports.yahoo.com/mlb/rss/"
+
+# How many rows we keep in `mlb_news_seen` before pruning. Yahoo's feed has
+# ~20 items at a time, so 500 covers comfortably more than a week of churn.
+MAX_LEDGER_ROWS = 500
+
+# Same DB connection settings as other backend pipeline modules.
+DATABASE_URL = "mysql+pymysql://root:{password}@{host}:3306/{db}".format(
+    password=os.getenv("MYSQL_ROOT_PASSWORD", ""),
+    host=os.getenv("MYSQL_HOST", "db"),
+    db=os.getenv("MYSQL_DATABASE", "ppa_dun_api"),
+)
+_engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+_SessionLocal = sessionmaker(bind=_engine, autocommit=False, autoflush=False)
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    guid: str
+    title: str
+    link: Optional[str]
+
+
+def _fetch_rss_items() -> List[NewsItem]:
+    """Fetch the Yahoo MLB RSS feed and return items as (guid, title, link).
+
+    Items without a `guid` (or with empty title) are skipped — without a stable
+    id we have no way to dedup, and an empty title would render an empty toast.
+    """
+    try:
+        resp = requests.get(RSS_URL, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.warning(f"[mlb_news] RSS fetch failed: {e}")
+        return []
+
+    try:
+        root = ET.fromstring(resp.content)
+    except ET.ParseError as e:
+        logger.warning(f"[mlb_news] RSS parse failed: {e}")
+        return []
+
+    items: List[NewsItem] = []
+    for it in root.iter("item"):
+        guid_el = it.find("guid")
+        title_el = it.find("title")
+        link_el = it.find("link")
+        guid = (guid_el.text or "").strip() if guid_el is not None else ""
+        title = (title_el.text or "").strip() if title_el is not None else ""
+        if not guid or not title:
+            continue
+        link = (link_el.text or "").strip() if link_el is not None else None
+        items.append(NewsItem(guid=guid, title=title, link=link))
+    return items
+
+
+def _prune_old(session, keep: int = MAX_LEDGER_ROWS) -> None:
+    """Keep only the `keep` most-recent rows in `mlb_news_seen`."""
+    total = session.query(MLBNewsSeen).count()
+    if total <= keep:
+        return
+    # Delete the oldest (total - keep) rows.
+    oldest_ids_subq = (
+        session.query(MLBNewsSeen.id)
+        .order_by(MLBNewsSeen.seen_at.asc())
+        .limit(total - keep)
+        .all()
+    )
+    ids_to_delete = [row.id for row in oldest_ids_subq]
+    if ids_to_delete:
+        session.query(MLBNewsSeen).filter(MLBNewsSeen.id.in_(ids_to_delete)).delete(
+            synchronize_session=False
+        )
+
+
+def find_new_items() -> List[NewsItem]:
+    """Poll the RSS feed and return only items we have not yet seen.
+
+    Side effect: every fetched item's guid is written to the ledger so future
+    polls will treat it as "seen". On the very first call (empty ledger) we
+    still write everything but return an empty list — no backlog spam.
+    """
+    items = _fetch_rss_items()
+    if not items:
+        return []
+
+    session = _SessionLocal()
+    try:
+        bootstrap = session.query(MLBNewsSeen).first() is None
+
+        existing_guids = {
+            row.guid
+            for row in session.query(MLBNewsSeen.guid)
+            .filter(MLBNewsSeen.guid.in_([it.guid for it in items]))
+            .all()
+        }
+        new_items = [it for it in items if it.guid not in existing_guids]
+        if not new_items:
+            return []
+
+        for it in new_items:
+            session.add(MLBNewsSeen(guid=it.guid, title=it.title[:500]))
+
+        _prune_old(session)
+        session.commit()
+
+        if bootstrap:
+            logger.info(
+                f"[mlb_news] bootstrap — recorded {len(new_items)} items, "
+                "skipping notifications for this cycle"
+            )
+            return []
+
+        logger.info(f"[mlb_news] {len(new_items)} new items to notify")
+        return new_items
+    except Exception as e:
+        session.rollback()
+        logger.warning(f"[mlb_news] ledger update failed: {e}")
+        return []
+    finally:
+        session.close()

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -322,3 +322,18 @@ class APIRequestLog(Base):
     status      = Column(Integer,     nullable=True)               # HTTP response code
     duration_ms = Column(Float,       nullable=True)               # request processing time
     ts          = Column(DateTime,    nullable=False, default=datetime.utcnow, index=True)
+
+
+# ── MLBNewsSeen ───────────────────────────────────────────────────────────────
+# Dedup ledger for the MLB news RSS poller. Each row is one feed item we have
+# already observed and pushed to the BE webhook. Indexed by guid so the 30-min
+# poller can quickly check "have we seen this?" before notifying again.
+# Old rows are pruned by the poller itself (cap at MAX_ROWS) to bound growth.
+
+class MLBNewsSeen(Base):
+    __tablename__ = "mlb_news_seen"
+
+    id          = Column(Integer, primary_key=True, index=True)
+    guid        = Column(String(512), unique=True, nullable=False, index=True)
+    title       = Column(String(512), nullable=True)
+    seen_at     = Column(DateTime,    nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
Closes #138.

## Summary

- New ORM model `MLBNewsSeen` (table `mlb_news_seen`) — dedup ledger keyed by RSS guid. Capped at 500 rows; poller prunes oldest on every cycle.
- New module `backend/data/sources/mlb_news.py` — Yahoo Sports MLB RSS fetch + stdlib XML parse + guid-based new-item detection. Bootstrap cycle (empty ledger) records items but returns none — prevents toast flood on first deploy.
- `daily_update.py`: new `_news_fetch_cycle()` posts each new item to BE `/internal/notify` with `event_type="NEWS"`, `player_id="MLB_NEWS"` (placeholder, BE schema requires non-null), `message=<title>`.
- Scheduler: new job on `CronTrigger(minute="5,35")` — 30-minute cadence offset by 5 min from the existing injury/depth cycle to avoid stacked outbound HTTP bursts.

## Notes

- Table auto-created by SQLAlchemy `Base.metadata.create_all` on backend startup — no manual migration needed.
- FE side will render `event_type="NEWS"` as "📰 MLB NEWS" prefix (already shipped on the fe branch).

## Test plan

- [ ] Deploy and confirm `mlb_news_seen` table created.
- [ ] First cycle: backend log shows "bootstrap — recorded N items, skipping notifications".
- [ ] Second cycle onward: any newly-published Yahoo MLB story triggers one webhook POST and one row in BE `notifications`.
- [ ] FE Draft Kit (with Issue #141 merged) shows the toast.